### PR TITLE
Benefit JS 안드로이드 샘플앱에서 benefit Android SDK 2.0.2를 사용

### DIFF
--- a/buzzad-benefit-web/android/app/build.gradle
+++ b/buzzad-benefit-web/android/app/build.gradle
@@ -17,6 +17,10 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 dependencies {
@@ -24,7 +28,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.0.2'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
 
-    implementation ("com.buzzvil:buzzad-benefit:1.7.0") {
+    implementation ("com.buzzvil:buzzad-benefit:2.0.2") {
         // 현재 Pop 을 연동하고 있지 않다면 아래 코드를 추가해야 합니다.
         exclude group: 'com.buzzvil', module: 'buzzad-benefit-pop'
         // 현재 Notification 을 연동하고 있지 않다면 아래 코드를 추가해야 합니다.

--- a/buzzad-benefit-web/android/app/src/main/AndroidManifest.xml
+++ b/buzzad-benefit-web/android/app/src/main/AndroidManifest.xml
@@ -18,9 +18,9 @@
             </intent-filter>
         </activity>
 
-        <!-- Change the value of APP_KEY to yours. -->
+        <!-- Change the value 0123456789 of APP_KEY to yours. -->
         <meta-data
             android:name="com.buzzvil.APP_KEY"
-            android:value="app-pub-310600461728380" />
+            android:value="app-pub-0123456789" />
     </application>
 </manifest>

--- a/buzzad-benefit-web/android/app/src/main/AndroidManifest.xml
+++ b/buzzad-benefit-web/android/app/src/main/AndroidManifest.xml
@@ -18,9 +18,9 @@
             </intent-filter>
         </activity>
 
-        <!-- Change the value 0123456789 of APP_KEY to yours. -->
+        <!-- Change the value 000000000000 of APP_KEY to yours. -->
         <meta-data
             android:name="com.buzzvil.APP_KEY"
-            android:value="app-pub-0123456789" />
+            android:value="app-pub-000000000000" />
     </application>
 </manifest>

--- a/buzzad-benefit-web/android/app/src/main/AndroidManifest.xml
+++ b/buzzad-benefit-web/android/app/src/main/AndroidManifest.xml
@@ -17,6 +17,10 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-    </application>
 
+        <!-- Change the value of APP_KEY to yours. -->
+        <meta-data
+            android:name="com.buzzvil.APP_KEY"
+            android:value="app-pub-310600461728380" />
+    </application>
 </manifest>

--- a/buzzad-benefit-web/android/app/src/main/java/com/buzzvil/benefit/web/App.java
+++ b/buzzad-benefit-web/android/app/src/main/java/com/buzzvil/benefit/web/App.java
@@ -8,12 +8,9 @@ import com.buzzvil.buzzad.benefit.BuzzAdBenefitConfig;
 public class App extends Application {
     public static final String MY_WEB_PAGE = "https://buzzvil.github.io/buzzad-benefit-sdk-publisher-web/";
 
-    // This is for test. use your APP_ID
-    final String YOUR_APP_ID = "YOUR_APP_ID";
-
     @Override
     public void onCreate() {
         super.onCreate();
-        BuzzAdBenefit.init(this, new BuzzAdBenefitConfig.Builder(YOUR_APP_ID).build());
+        BuzzAdBenefit.init(this, new BuzzAdBenefitConfig.Builder(this).build());
     }
 }

--- a/buzzad-benefit-web/android/app/src/main/java/com/buzzvil/benefit/web/MainActivity.java
+++ b/buzzad-benefit-web/android/app/src/main/java/com/buzzvil/benefit/web/MainActivity.java
@@ -6,6 +6,7 @@ import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
 import android.text.TextUtils;
+import android.util.Log;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
 import android.widget.CompoundButton;
@@ -119,7 +120,6 @@ public class MainActivity extends AppCompatActivity {
                 .build();
 
         BuzzAdBenefit.setUserProfile(userProfile);
-        this.setLoginUi(userId);
     }
 
     private void logout() {
@@ -136,6 +136,7 @@ public class MainActivity extends AppCompatActivity {
             BuzzAdBenefit.registerSessionReadyBroadcastReceiver(this, new BroadcastReceiver() {
                 @Override
                 public void onReceive(Context context, Intent intent) {
+                    Log.d("JSSDK", "REGISTER SESSION READY");
                     BuzzAdBenefit.unregisterSessionReadyBroadcastReceiver(MainActivity.this, this);
                     final UserProfile userProfile = BuzzAdBenefit.getUserProfile();
                     setLoginUi(userProfile.getUserId());

--- a/buzzad-benefit-web/android/app/src/main/java/com/buzzvil/benefit/web/MainActivity.java
+++ b/buzzad-benefit-web/android/app/src/main/java/com/buzzvil/benefit/web/MainActivity.java
@@ -6,7 +6,6 @@ import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
 import android.text.TextUtils;
-import android.util.Log;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
 import android.widget.CompoundButton;
@@ -131,20 +130,14 @@ public class MainActivity extends AppCompatActivity {
      * If UserProfile is setup, set to Login UI
      */
     private void setupBuzzAdBenefitSessionListener() {
-        final UserProfile userProfile = BuzzAdBenefit.getUserProfile();
-        if (userProfile == null || TextUtils.isEmpty(userProfile.getSessionKey())) {
-            BuzzAdBenefit.registerSessionReadyBroadcastReceiver(this, new BroadcastReceiver() {
-                @Override
-                public void onReceive(Context context, Intent intent) {
-                    Log.d("JSSDK", "REGISTER SESSION READY");
-                    BuzzAdBenefit.unregisterSessionReadyBroadcastReceiver(MainActivity.this, this);
-                    final UserProfile userProfile = BuzzAdBenefit.getUserProfile();
-                    setLoginUi(userProfile.getUserId());
-                }
-            });
-        } else {
-            setLoginUi(userProfile.getUserId());
-        }
+        BuzzAdBenefit.registerSessionReadyBroadcastReceiver(this, new BroadcastReceiver() {
+            @Override
+            public void onReceive(Context context, Intent intent) {
+                BuzzAdBenefit.unregisterSessionReadyBroadcastReceiver(MainActivity.this, this);
+                final UserProfile userProfile = BuzzAdBenefit.getUserProfile();
+                setLoginUi(userProfile.getUserId());
+            }
+        });
     }
 
     /**

--- a/buzzad-benefit-web/android/build.gradle
+++ b/buzzad-benefit-web/android/build.gradle
@@ -16,6 +16,7 @@ buildscript {
 
 allprojects {
     repositories {
+        mavenLocal()
         google()
         jcenter()
         maven { url "https://dl.bintray.com/buzzvil/maven/" }

--- a/buzzad-benefit-web/android/build.gradle
+++ b/buzzad-benefit-web/android/build.gradle
@@ -16,7 +16,6 @@ buildscript {
 
 allprojects {
     repositories {
-        mavenLocal()
         google()
         jcenter()
         maven { url "https://dl.bintray.com/buzzvil/maven/" }


### PR DESCRIPTION
Benefit JS용 안드로이드 샘플앱에서 Benefit 안드로이드 SDK 2.0.2 버전을 사용하도록 변경하였습니다.
* 연동 버전을 1.7.0에서 2.0.2로 변경
* APP_KEY를 AndroidManifest로 옮김
* compileOptions에 VERSION_1_8 추가 (없으면 빌드 안됨)
* SessionReadyBroadcastReceiver 사용할 때 불필요한 분기 처리 제거 (API 내부에서 같은 분기처리를 하고 있어서, 해당 분기처리가 없어도 세션이 있는 경우 바로 콜백이 실행됨)