### PR TITLE
Benefit JS 샘플 웹페이지에서 JS SDK 1.2.0 사용. 코드 정리

### DIFF
--- a/buzzad-benefit-web/web/ids.js
+++ b/buzzad-benefit-web/web/ids.js
@@ -1,0 +1,4 @@
+// Replace the value '0123456789' to your APP_ID and UNIT ID
+const APP_ID = '0123456789';
+const UNIT_ID_ANDROID = '0123456789';
+const UNIT_ID_IOS = '0123456789';

--- a/buzzad-benefit-web/web/index.html
+++ b/buzzad-benefit-web/web/index.html
@@ -97,6 +97,7 @@
     <!-- end -->
 
     <script src="https://buzz-js.buzzvil.com/buzzad-benefit-sdk/1.2.0/buzzad-benefit-sdk.js"></script>
+    <script src="ids.js"></script>
     <script src="index.js"></script>
   </body>
 </html>

--- a/buzzad-benefit-web/web/index.html
+++ b/buzzad-benefit-web/web/index.html
@@ -96,7 +96,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.js"></script>
     <!-- end -->
 
-    <script src="https://buzz-js.buzzvil.com/buzzad-benefit-sdk/1.0.4/buzzad-benefit-sdk.js"></script>
+    <script src="https://buzz-js.buzzvil.com/buzzad-benefit-sdk/1.2.0/buzzad-benefit-sdk.js"></script>
     <script src="index.js"></script>
   </body>
 </html>

--- a/buzzad-benefit-web/web/index.js
+++ b/buzzad-benefit-web/web/index.js
@@ -52,7 +52,7 @@ function log(message, bad) {
 
   // Initiate SDK
   const config = {
-    appId: '310600461728380'
+    appId: APP_ID
   }
 
   BuzzAdBenefit.init(config);
@@ -62,8 +62,8 @@ function log(message, bad) {
     // Setup Ad Placement
     const loadConfig = {
       unitId: {
-        android: '232661007718829',
-        ios: '131298264757814',
+        android: UNIT_ID_ANDROID,
+        ios: UNIT_ID_IOS,
       }
     }
 

--- a/buzzad-benefit-web/web/index.js
+++ b/buzzad-benefit-web/web/index.js
@@ -57,8 +57,6 @@ function log(message, bad) {
 
   BuzzAdBenefit.init(config);
 
-  var ads = [];
-
   function loadAd() {
     setLoginUi(BuzzAdBenefit.instance.core.userProfile.userId);
     // Setup Ad Placement
@@ -66,17 +64,16 @@ function log(message, bad) {
       unitId: {
         android: '232661007718829',
         ios: '131298264757814',
-      },
-      count: 3
+      }
     }
 
     BuzzAdBenefit.loadAd(loadConfig)
-      .then(function (nativeAds) {
+      .then(function (nativeAd) {
         log('ON AD LOADED: An ad is loaded.');
-        ads = ads.concat(nativeAds);
-        populateAd(ads.shift());
+        populateAd(nativeAd);
       }).catch(function(error) {
         log('ON LOAD ERROR: An error is detected: ' + error.message, true);
+        hideAd();
       });
   }
 
@@ -85,11 +82,7 @@ function log(message, bad) {
   }
 
   function reloadAd() {
-    if (ads.length) {
-      populateAd(ads.shift());
-    } else {
-      loadAd();
-    }
+    loadAd();
   }
 
   window.reloadAd = reloadAd;
@@ -122,6 +115,11 @@ function log(message, bad) {
     rootView.getElementsByClassName('body')[0].innerHTML = nativeAd.description;
 
     updateCtaView(rootView.getElementsByClassName('cta')[0], nativeAd);
+  }
+
+  function hideAd() {
+    const rootView = document.getElementById('nativeAd');
+    rootView.style.display = 'none';
   }
 
   function populateAd(nativeAd) {


### PR DESCRIPTION
Benefit JS 샘플 웹페이지에서 JS SDK 1.2.0을 사용하도록 하고, 코드를 약간 정리하였습니다.
* Benefit JS SDK를 1.0.4에서 1.2.0을 사용하도록 변경
* 코드 가독성을 위해 광고를 1개만 요청하게 하고, 광고 큐를 없앰
* NO_FILL 등의 사유로 보여줄 광고가 없는 경우 광고 영역을 보이지 않게 함