### PR TITLE
퍼블리셔의 코드에서 생긴 에러가 SDK에서 생긴 것처럼 보이지 않도록 코드 수정

### DIFF
--- a/buzzad-benefit-web/web/index.js
+++ b/buzzad-benefit-web/web/index.js
@@ -71,7 +71,7 @@ function log(message, bad) {
       .then(function (nativeAd) {
         log('ON AD LOADED: An ad is loaded.');
         populateAd(nativeAd);
-      }).catch(function(error) {
+      }, function(error) {
         log('ON LOAD ERROR: An error is detected: ' + error.message, true);
         hideAd();
       });
@@ -88,8 +88,7 @@ function log(message, bad) {
   window.reloadAd = reloadAd;
 
   BuzzAdBenefit.ensureAuthenticated
-    .then(loadAd)
-    .catch(onError);
+    .then(loadAd, onError);
 
   function updateCtaView(ctaView, nativeAd) {
     var ctaTextHeader = '';


### PR DESCRIPTION
퍼블리셔가 구현한 callback에서 에러가 발생했을 때 아래의 catch문에서 그 에러가 잡혀서 마치 SDK에서 에러가 생긴 것처럼 보이는 문제를 수정하였습니다.