### PR TITLE
bump up pedometer sdk version to 1.1.2

### DIFF
--- a/buzz-pedometer/app/build.gradle
+++ b/buzz-pedometer/app/build.gradle
@@ -30,5 +30,5 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 
     implementation 'androidx.multidex:multidex:2.0.1'
-    implementation 'com.buzzvil:buzz-pedometer-sdk:1.0.0'
+    implementation 'com.buzzvil:buzz-pedometer-sdk:1.1.2'
 }

--- a/buzz-pedometer/app/src/main/java/com/buzzvil/pedometer/sample/MainActivity.java
+++ b/buzz-pedometer/app/src/main/java/com/buzzvil/pedometer/sample/MainActivity.java
@@ -237,7 +237,7 @@ public class MainActivity extends AppCompatActivity {
 
         tvRedeemable.setText(String.valueOf(redeemableMilestones));
         tvRewarded.setText(String.valueOf(rewardedMilestones));
-        btRequestReward.setEnabled("0" != tvRedeemable.getText());
+        btRequestReward.setEnabled(!tvRedeemable.getText().toString().equals("0"));
     }
 
     private void updateStepUI(long value) {


### PR DESCRIPTION
Pedometer sdk의 버전을 1.1.2 로 명시적으로 버전을 올렸습니다. 

그리고 redeemable milestone이 없는 상황에서 Request reward 버튼이 enable되는 UI버그가 있어 수정했습니다. 