### PR TITLE
BuzzAdPopSample lazy init

### DIFF
--- a/buzzad-benefit-pop/app/src/main/java/com/buzzvil/buzzad/benefit/popsample/java/App.java
+++ b/buzzad-benefit-pop/app/src/main/java/com/buzzvil/buzzad/benefit/popsample/java/App.java
@@ -1,10 +1,13 @@
 package com.buzzvil.buzzad.benefit.popsample.java;
 
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.util.Log;
+
 import androidx.multidex.MultiDexApplication;
 
 import com.buzzvil.buzzad.benefit.BuzzAdBenefit;
 import com.buzzvil.buzzad.benefit.BuzzAdBenefitConfig;
-import com.buzzvil.buzzad.benefit.core.models.UserProfile;
 import com.buzzvil.buzzad.benefit.pop.DefaultPopHeaderViewAdapter;
 import com.buzzvil.buzzad.benefit.pop.PopConfig;
 import com.buzzvil.buzzad.benefit.pop.PopNotificationConfig;
@@ -17,18 +20,36 @@ import com.buzzvil.buzzad.benefit.popsample.java.custom.CustomPopToolbarHolder;
 import com.buzzvil.buzzad.benefit.presentation.feed.FeedConfig;
 
 public class App extends MultiDexApplication {
+    public static final String TAG = "App";
+    public static final String BUZZ_AD_PREFERENCE = "BUZZ_AD_PREFERENCE";
+    public static final String POP_ENABLED = "popInitialized";
     public static final String UNIT_ID_POP = "236027834764095";
-    public boolean isBenefitInitialized = false;
+    public boolean isBuzzAdBenefitInitialized = false;
+    private SharedPreferences sharedPref;
+
     @Override
     public void onCreate() {
         super.onCreate();
-
+        sharedPref = getApplicationContext().getSharedPreferences(BUZZ_AD_PREFERENCE, Context.MODE_PRIVATE);
+        boolean popEnabled = sharedPref.getBoolean(POP_ENABLED, false);
+        Log.d(TAG, "onCreate popEnabled = " + popEnabled);
+        if (popEnabled) {
+            Log.d(TAG, "onCreate popEnabled == true initBuzzAdBenefit");
+            initBuzzAdBenefit();
+        }
 //        initBuzzAdBenefit();
 //        initBuzzAdBenefitWithCustomPopHeaderViewAdapter(); // User this for custom pop header view adapter
 //        initBuzzAdBenefitWithCustomControlService(); // Use this for custom pop notification
     }
 
+    public void clearBuzzAdBenefit() {
+        Log.d(TAG, "clearBuzzAdBenefit");
+        isBuzzAdBenefitInitialized = false;
+        sharedPref.edit().putBoolean(POP_ENABLED, false).apply();
+    }
+
     public void initBuzzAdBenefit() {
+        Log.d(TAG, "initBuzzAdBenefit");
         final FeedConfig feedConfig = new FeedConfig.Builder(getApplicationContext(), UNIT_ID_POP)
                 // DefaultPopToolbarHolder: DefaultToolbar
                 // TemplatePopToolbarHolder: Minimum customize, pop feed icon, name, button
@@ -57,16 +78,11 @@ public class App extends MultiDexApplication {
                 .add(popConfig)
                 .build();
         BuzzAdBenefit.init(this, buzzAdBenefitConfig);
+        sharedPref.edit().putBoolean(POP_ENABLED, true).apply();
 
-        isBenefitInitialized = true;
-
-        final UserProfile userProfile = new UserProfile.Builder(BuzzAdBenefit.getUserProfile())
-                .userId("SAMPLE_USER_ID")
-                .gender(UserProfile.Gender.FEMALE)
-                .birthYear(1993)
-                .build();
-        BuzzAdBenefit.setUserProfile(userProfile);
+        isBuzzAdBenefitInitialized = true;
     }
+
     /**
      * [CUSTOM_POP_HEADER_VIEW_ADAPTER] Set custom CustomPopHeaderViewAdapter
      */
@@ -96,13 +112,6 @@ public class App extends MultiDexApplication {
                 .add(popConfig)
                 .build();
         BuzzAdBenefit.init(this, buzzAdBenefitConfig);
-
-        final UserProfile userProfile = new UserProfile.Builder(BuzzAdBenefit.getUserProfile())
-                .userId("SAMPLE_USER_ID")
-                .gender(UserProfile.Gender.FEMALE)
-                .birthYear(1993)
-                .build();
-        BuzzAdBenefit.setUserProfile(userProfile);
     }
 
     /**
@@ -125,12 +134,5 @@ public class App extends MultiDexApplication {
                 .add(popConfig)
                 .build();
         BuzzAdBenefit.init(this, buzzAdBenefitConfig);
-
-        final UserProfile userProfile = new UserProfile.Builder(BuzzAdBenefit.getUserProfile())
-                .userId("SAMPLE_USER_ID")
-                .gender(UserProfile.Gender.FEMALE)
-                .birthYear(1993)
-                .build();
-        BuzzAdBenefit.setUserProfile(userProfile);
     }
 }

--- a/buzzad-benefit-pop/app/src/main/java/com/buzzvil/buzzad/benefit/popsample/java/App.java
+++ b/buzzad-benefit-pop/app/src/main/java/com/buzzvil/buzzad/benefit/popsample/java/App.java
@@ -12,7 +12,7 @@ public class App extends MultiDexApplication {
     public static final String TAG = "App";
     public static final String BUZZ_AD_PREFERENCE = "BUZZ_AD_PREFERENCE";
     public static final String UNIT_ID_POP = "236027834764095";
-    private BuzzAdPopController buzzAdBenefitController;
+    private BuzzAdBenefitController buzzAdBenefitController;
 
     @Override
     public void onCreate() {
@@ -22,7 +22,7 @@ public class App extends MultiDexApplication {
 
     private void initBuzzAdBenefitController() {
         SharedPreferences sharedPref = getApplicationContext().getSharedPreferences(BUZZ_AD_PREFERENCE, Context.MODE_PRIVATE);
-        buzzAdBenefitController = new BuzzAdPopController(getApplicationContext(), sharedPref);
+        buzzAdBenefitController = new BuzzAdBenefitController(getApplicationContext(), sharedPref);
 
         boolean buzzAdBenefitEnabled = buzzAdBenefitController.isBuzzAdBenefitEnabled();
         Log.d(TAG, "onCreate buzzAdBenefitEnabled == " + buzzAdBenefitEnabled);

--- a/buzzad-benefit-pop/app/src/main/java/com/buzzvil/buzzad/benefit/popsample/java/App.java
+++ b/buzzad-benefit-pop/app/src/main/java/com/buzzvil/buzzad/benefit/popsample/java/App.java
@@ -6,151 +6,49 @@ import android.util.Log;
 
 import androidx.multidex.MultiDexApplication;
 
-import com.buzzvil.buzzad.benefit.BuzzAdBenefit;
-import com.buzzvil.buzzad.benefit.BuzzAdBenefitConfig;
 import com.buzzvil.buzzad.benefit.pop.BuzzAdPop;
-import com.buzzvil.buzzad.benefit.pop.DefaultPopHeaderViewAdapter;
-import com.buzzvil.buzzad.benefit.pop.PopConfig;
-import com.buzzvil.buzzad.benefit.pop.PopNotificationConfig;
-import com.buzzvil.buzzad.benefit.pop.SidePosition;
-import com.buzzvil.buzzad.benefit.pop.toolbar.DefaultPopToolbarHolder;
-import com.buzzvil.buzzad.benefit.popsample.R;
-import com.buzzvil.buzzad.benefit.popsample.java.custom.CustomControlService;
-import com.buzzvil.buzzad.benefit.popsample.java.custom.CustomPopHeaderViewAdapter;
-import com.buzzvil.buzzad.benefit.popsample.java.custom.CustomPopToolbarHolder;
-import com.buzzvil.buzzad.benefit.presentation.feed.FeedConfig;
 
 public class App extends MultiDexApplication {
     public static final String TAG = "App";
     public static final String BUZZ_AD_PREFERENCE = "BUZZ_AD_PREFERENCE";
     public static final String POP_ENABLED = "popInitialized";
     public static final String UNIT_ID_POP = "236027834764095";
-    public boolean isBuzzAdBenefitInitialized = false;
-    private BuzzAdPop buzzAdPop = null;
-    private SharedPreferences sharedPref;
+    private BuzzAdPopController buzzAdPopController;
 
     @Override
     public void onCreate() {
         super.onCreate();
-        sharedPref = getApplicationContext().getSharedPreferences(BUZZ_AD_PREFERENCE, Context.MODE_PRIVATE);
+        initBuzzAdBenefitController();
+    }
+
+    private void initBuzzAdBenefitController() {
+        SharedPreferences sharedPref = getApplicationContext().getSharedPreferences(BUZZ_AD_PREFERENCE, Context.MODE_PRIVATE);
         boolean popEnabled = sharedPref.getBoolean(POP_ENABLED, false);
+        buzzAdPopController = new BuzzAdPopController(getApplicationContext(), sharedPref);
         Log.d(TAG, "onCreate popEnabled = " + popEnabled);
         if (popEnabled) {
             Log.d(TAG, "onCreate popEnabled == true initBuzzAdBenefit");
-            initBuzzAdBenefit();
+            buzzAdPopController.initBuzzAdBenefit();
         }
-//        initBuzzAdBenefit();
-//        initBuzzAdBenefitWithCustomPopHeaderViewAdapter(); // User this for custom pop header view adapter
-//        initBuzzAdBenefitWithCustomControlService(); // Use this for custom pop notification
+    }
+
+    public boolean isBuzzAdBenefitInitialized() {
+        return buzzAdPopController.isBuzzAdBenefitInitialized;
     }
 
     public void clearBuzzAdBenefit() {
-        Log.d(TAG, "clearBuzzAdBenefit");
-        isBuzzAdBenefitInitialized = false;
-        buzzAdPop.removePop(getApplicationContext());
-        buzzAdPop = null;
-        sharedPref.edit().putBoolean(POP_ENABLED, false).apply();
+        buzzAdPopController.clearBuzzAdBenefit();
     }
 
     public void buildBuzzAdPop() {
-        if (isBuzzAdBenefitInitialized && buzzAdPop == null) {
-            Log.d(TAG, "getBuzzAdPop success");
-            buzzAdPop = new BuzzAdPop(getApplicationContext(), App.UNIT_ID_POP);
-        } else {
-            Log.d(TAG, "getBuzzAdPop is already initialized");
-        }
+        buzzAdPopController.buildBuzzAdPop();
     }
 
     public BuzzAdPop getBuzzAdPop() {
-        return buzzAdPop;
+        return buzzAdPopController.getBuzzAdPop();
     }
 
     public void initBuzzAdBenefit() {
-        Log.d(TAG, "initBuzzAdBenefit");
-        final FeedConfig feedConfig = new FeedConfig.Builder(getApplicationContext(), UNIT_ID_POP)
-                // DefaultPopToolbarHolder: DefaultToolbar
-                // TemplatePopToolbarHolder: Minimum customize, pop feed icon, name, button
-                // CustomPopToolbarHolder: Use layout for toolbar
-                .feedToolbarHolderClass(CustomPopToolbarHolder.class)
-                .feedHeaderViewAdapterClass(DefaultPopHeaderViewAdapter.class)
-                .articlesEnabled(true)
-                .articleInAppLandingEnabled(true)
-                .build();
-        final PopNotificationConfig popNotificationConfig = new PopNotificationConfig.Builder(getApplicationContext())
-                .smallIconResId(R.drawable.ic_notification_pop_gift)
-                .titleResId(R.string.pop_notification_title)
-                .textResId(R.string.pop_notification_text)
-                .colorResId(R.color.colorPrimary)
-                .notificationId(1021)
-                .build();
-        final PopConfig popConfig = new PopConfig.Builder(getApplicationContext(), UNIT_ID_POP)
-                .initialSidePosition(new SidePosition(SidePosition.Side.RIGHT, 0.6f))
-                .initialPopIdleMode(PopConfig.PopIdleMode.INVISIBLE)
-                .feedConfig(feedConfig)
-                .idleTimeInMillis(10_000)
-                .popNotificationConfig(popNotificationConfig)
-                .previewIntervalInMillis(1000) // for test
-                .build();
-
-        final BuzzAdBenefitConfig buzzAdBenefitConfig = new BuzzAdBenefitConfig.Builder(this)
-                .add(popConfig)
-                .build();
-        BuzzAdBenefit.init(this, buzzAdBenefitConfig);
-        sharedPref.edit().putBoolean(POP_ENABLED, true).apply();
-
-        isBuzzAdBenefitInitialized = true;
-    }
-
-    /**
-     * [CUSTOM_POP_HEADER_VIEW_ADAPTER] Set custom CustomPopHeaderViewAdapter
-     */
-    private void initBuzzAdBenefitWithCustomPopHeaderViewAdapter() {
-        final FeedConfig feedConfig = new FeedConfig.Builder(getApplicationContext(), UNIT_ID_POP)
-                .feedToolbarHolderClass(DefaultPopToolbarHolder.class)
-                .feedHeaderViewAdapterClass(CustomPopHeaderViewAdapter.class)
-                .articlesEnabled(true)
-                .articleInAppLandingEnabled(true)
-                .build();
-        final PopNotificationConfig popNotificationConfig = new PopNotificationConfig.Builder(getApplicationContext())
-                .smallIconResId(R.drawable.ic_notification_pop_gift)
-                .titleResId(R.string.pop_notification_title)
-                .textResId(R.string.pop_notification_text)
-                .colorResId(R.color.colorPrimary)
-                .notificationId(1021)
-                .build();
-        final PopConfig popConfig = new PopConfig.Builder(getApplicationContext(), UNIT_ID_POP)
-                .initialSidePosition(new SidePosition(SidePosition.Side.RIGHT, 0.6f))
-                .initialPopIdleMode(PopConfig.PopIdleMode.INVISIBLE)
-                .feedConfig(feedConfig)
-                .popNotificationConfig(popNotificationConfig)
-                .previewIntervalInMillis(1000) // for test
-                .build();
-
-        final BuzzAdBenefitConfig buzzAdBenefitConfig = new BuzzAdBenefitConfig.Builder(this)
-                .add(popConfig)
-                .build();
-        BuzzAdBenefit.init(this, buzzAdBenefitConfig);
-    }
-
-    /**
-     * [CUSTOM_POP_CONTROL_SERVICE] Set custom PopControlService
-     */
-    private void initBuzzAdBenefitWithCustomControlService() {
-        final PopNotificationConfig popNotificationConfig = new PopNotificationConfig.Builder(getApplicationContext())
-                .smallIconResId(R.drawable.ic_notification_pop_gift)
-                .notificationId(1021)
-                .build();
-
-        final PopConfig popConfig = new PopConfig.Builder(getApplicationContext(), UNIT_ID_POP)
-                .initialSidePosition(new SidePosition(SidePosition.Side.RIGHT, 0.6f))
-                .initialPopIdleMode(PopConfig.PopIdleMode.INVISIBLE)
-                .controlService(CustomControlService.class)
-                .popNotificationConfig(popNotificationConfig)
-                .build();
-
-        final BuzzAdBenefitConfig buzzAdBenefitConfig = new BuzzAdBenefitConfig.Builder(this)
-                .add(popConfig)
-                .build();
-        BuzzAdBenefit.init(this, buzzAdBenefitConfig);
+        buzzAdPopController.initBuzzAdBenefit();
     }
 }

--- a/buzzad-benefit-pop/app/src/main/java/com/buzzvil/buzzad/benefit/popsample/java/App.java
+++ b/buzzad-benefit-pop/app/src/main/java/com/buzzvil/buzzad/benefit/popsample/java/App.java
@@ -18,17 +18,17 @@ import com.buzzvil.buzzad.benefit.presentation.feed.FeedConfig;
 
 public class App extends MultiDexApplication {
     public static final String UNIT_ID_POP = "236027834764095";
-
+    public boolean isBenefitInitialized = false;
     @Override
     public void onCreate() {
         super.onCreate();
 
-        initBuzzAdBenefit();
+//        initBuzzAdBenefit();
 //        initBuzzAdBenefitWithCustomPopHeaderViewAdapter(); // User this for custom pop header view adapter
 //        initBuzzAdBenefitWithCustomControlService(); // Use this for custom pop notification
     }
 
-    private void initBuzzAdBenefit() {
+    public void initBuzzAdBenefit() {
         final FeedConfig feedConfig = new FeedConfig.Builder(getApplicationContext(), UNIT_ID_POP)
                 // DefaultPopToolbarHolder: DefaultToolbar
                 // TemplatePopToolbarHolder: Minimum customize, pop feed icon, name, button
@@ -57,6 +57,8 @@ public class App extends MultiDexApplication {
                 .add(popConfig)
                 .build();
         BuzzAdBenefit.init(this, buzzAdBenefitConfig);
+
+        isBenefitInitialized = true;
 
         final UserProfile userProfile = new UserProfile.Builder(BuzzAdBenefit.getUserProfile())
                 .userId("SAMPLE_USER_ID")

--- a/buzzad-benefit-pop/app/src/main/java/com/buzzvil/buzzad/benefit/popsample/java/App.java
+++ b/buzzad-benefit-pop/app/src/main/java/com/buzzvil/buzzad/benefit/popsample/java/App.java
@@ -8,6 +8,7 @@ import androidx.multidex.MultiDexApplication;
 
 import com.buzzvil.buzzad.benefit.BuzzAdBenefit;
 import com.buzzvil.buzzad.benefit.BuzzAdBenefitConfig;
+import com.buzzvil.buzzad.benefit.pop.BuzzAdPop;
 import com.buzzvil.buzzad.benefit.pop.DefaultPopHeaderViewAdapter;
 import com.buzzvil.buzzad.benefit.pop.PopConfig;
 import com.buzzvil.buzzad.benefit.pop.PopNotificationConfig;
@@ -25,6 +26,7 @@ public class App extends MultiDexApplication {
     public static final String POP_ENABLED = "popInitialized";
     public static final String UNIT_ID_POP = "236027834764095";
     public boolean isBuzzAdBenefitInitialized = false;
+    private BuzzAdPop buzzAdPop = null;
     private SharedPreferences sharedPref;
 
     @Override
@@ -45,7 +47,22 @@ public class App extends MultiDexApplication {
     public void clearBuzzAdBenefit() {
         Log.d(TAG, "clearBuzzAdBenefit");
         isBuzzAdBenefitInitialized = false;
+        buzzAdPop.removePop(getApplicationContext());
+        buzzAdPop = null;
         sharedPref.edit().putBoolean(POP_ENABLED, false).apply();
+    }
+
+    public void buildBuzzAdPop() {
+        if (isBuzzAdBenefitInitialized && buzzAdPop == null) {
+            Log.d(TAG, "getBuzzAdPop success");
+            buzzAdPop = new BuzzAdPop(getApplicationContext(), App.UNIT_ID_POP);
+        } else {
+            Log.d(TAG, "getBuzzAdPop is already initialized");
+        }
+    }
+
+    public BuzzAdPop getBuzzAdPop() {
+        return buzzAdPop;
     }
 
     public void initBuzzAdBenefit() {
@@ -70,6 +87,7 @@ public class App extends MultiDexApplication {
                 .initialSidePosition(new SidePosition(SidePosition.Side.RIGHT, 0.6f))
                 .initialPopIdleMode(PopConfig.PopIdleMode.INVISIBLE)
                 .feedConfig(feedConfig)
+                .idleTimeInMillis(10_000)
                 .popNotificationConfig(popNotificationConfig)
                 .previewIntervalInMillis(1000) // for test
                 .build();

--- a/buzzad-benefit-pop/app/src/main/java/com/buzzvil/buzzad/benefit/popsample/java/App.java
+++ b/buzzad-benefit-pop/app/src/main/java/com/buzzvil/buzzad/benefit/popsample/java/App.java
@@ -11,9 +11,8 @@ import com.buzzvil.buzzad.benefit.pop.BuzzAdPop;
 public class App extends MultiDexApplication {
     public static final String TAG = "App";
     public static final String BUZZ_AD_PREFERENCE = "BUZZ_AD_PREFERENCE";
-    public static final String POP_ENABLED = "popInitialized";
     public static final String UNIT_ID_POP = "236027834764095";
-    private BuzzAdPopController buzzAdPopController;
+    private BuzzAdPopController buzzAdBenefitController;
 
     @Override
     public void onCreate() {
@@ -23,32 +22,43 @@ public class App extends MultiDexApplication {
 
     private void initBuzzAdBenefitController() {
         SharedPreferences sharedPref = getApplicationContext().getSharedPreferences(BUZZ_AD_PREFERENCE, Context.MODE_PRIVATE);
-        boolean popEnabled = sharedPref.getBoolean(POP_ENABLED, false);
-        buzzAdPopController = new BuzzAdPopController(getApplicationContext(), sharedPref);
-        Log.d(TAG, "onCreate popEnabled = " + popEnabled);
-        if (popEnabled) {
-            Log.d(TAG, "onCreate popEnabled == true initBuzzAdBenefit");
-            buzzAdPopController.initBuzzAdBenefit();
+        buzzAdBenefitController = new BuzzAdPopController(getApplicationContext(), sharedPref);
+
+        boolean buzzAdBenefitEnabled = buzzAdBenefitController.isBuzzAdBenefitEnabled();
+        Log.d(TAG, "onCreate buzzAdBenefitEnabled == " + buzzAdBenefitEnabled);
+        if (buzzAdBenefitEnabled) {
+            Log.d(TAG, "onCreate buzzAdBenefitEnabled == true initBuzzAdBenefit");
+            buzzAdBenefitController.initBuzzAdBenefit();
+        } else {
+            Log.d(TAG, "onCreate buzzAdBenefitEnabled == false skip initBuzzAdBenefit");
         }
     }
 
     public boolean isBuzzAdBenefitInitialized() {
-        return buzzAdPopController.isBuzzAdBenefitInitialized;
+        return buzzAdBenefitController.isBuzzAdBenefitInitialized;
     }
 
     public void clearBuzzAdBenefit() {
-        buzzAdPopController.clearBuzzAdBenefit();
+        buzzAdBenefitController.clearBuzzAdBenefit();
     }
 
     public void buildBuzzAdPop() {
-        buzzAdPopController.buildBuzzAdPop();
+        try {
+            buzzAdBenefitController.buildBuzzAdPop();
+        } catch (IllegalStateException e) {
+            e.printStackTrace();
+        }
     }
 
     public BuzzAdPop getBuzzAdPop() {
-        return buzzAdPopController.getBuzzAdPop();
+        return buzzAdBenefitController.getBuzzAdPop();
     }
 
     public void initBuzzAdBenefit() {
-        buzzAdPopController.initBuzzAdBenefit();
+        if (!isBuzzAdBenefitInitialized()) {
+            buzzAdBenefitController.initBuzzAdBenefit();
+        } else {
+            Log.d(TAG, "initBuzzAdBenefit fail - already initialized");
+        }
     }
 }

--- a/buzzad-benefit-pop/app/src/main/java/com/buzzvil/buzzad/benefit/popsample/java/BuzzAdBenefitController.java
+++ b/buzzad-benefit-pop/app/src/main/java/com/buzzvil/buzzad/benefit/popsample/java/BuzzAdBenefitController.java
@@ -15,7 +15,7 @@ import com.buzzvil.buzzad.benefit.popsample.R;
 import com.buzzvil.buzzad.benefit.popsample.java.custom.CustomPopToolbarHolder;
 import com.buzzvil.buzzad.benefit.presentation.feed.FeedConfig;
 
-public class BuzzAdPopController {
+public class BuzzAdBenefitController {
     public static final String TAG = "App";
     public static final String BUZZ_AD_BENEFIT_ENABLED = "popInitialized";
     public static final String UNIT_ID_POP = "236027834764095";
@@ -24,7 +24,7 @@ public class BuzzAdPopController {
     private SharedPreferences sharedPref;
     private Context context;
 
-    BuzzAdPopController(Context context, SharedPreferences sharedPref) {
+    BuzzAdBenefitController(Context context, SharedPreferences sharedPref) {
         this.context = context;
         this.sharedPref = sharedPref;
     }

--- a/buzzad-benefit-pop/app/src/main/java/com/buzzvil/buzzad/benefit/popsample/java/BuzzAdPopController.java
+++ b/buzzad-benefit-pop/app/src/main/java/com/buzzvil/buzzad/benefit/popsample/java/BuzzAdPopController.java
@@ -11,10 +11,7 @@ import com.buzzvil.buzzad.benefit.pop.DefaultPopHeaderViewAdapter;
 import com.buzzvil.buzzad.benefit.pop.PopConfig;
 import com.buzzvil.buzzad.benefit.pop.PopNotificationConfig;
 import com.buzzvil.buzzad.benefit.pop.SidePosition;
-import com.buzzvil.buzzad.benefit.pop.toolbar.DefaultPopToolbarHolder;
 import com.buzzvil.buzzad.benefit.popsample.R;
-import com.buzzvil.buzzad.benefit.popsample.java.custom.CustomControlService;
-import com.buzzvil.buzzad.benefit.popsample.java.custom.CustomPopHeaderViewAdapter;
 import com.buzzvil.buzzad.benefit.popsample.java.custom.CustomPopToolbarHolder;
 import com.buzzvil.buzzad.benefit.presentation.feed.FeedConfig;
 
@@ -88,58 +85,5 @@ public class BuzzAdPopController {
         sharedPref.edit().putBoolean(POP_ENABLED, true).apply();
 
         isBuzzAdBenefitInitialized = true;
-    }
-
-    /**
-     * [CUSTOM_POP_HEADER_VIEW_ADAPTER] Set custom CustomPopHeaderViewAdapter
-     */
-    private void initBuzzAdBenefitWithCustomPopHeaderViewAdapter() {
-        final FeedConfig feedConfig = new FeedConfig.Builder(context, UNIT_ID_POP)
-                .feedToolbarHolderClass(DefaultPopToolbarHolder.class)
-                .feedHeaderViewAdapterClass(CustomPopHeaderViewAdapter.class)
-                .articlesEnabled(true)
-                .articleInAppLandingEnabled(true)
-                .build();
-        final PopNotificationConfig popNotificationConfig = new PopNotificationConfig.Builder(context)
-                .smallIconResId(R.drawable.ic_notification_pop_gift)
-                .titleResId(R.string.pop_notification_title)
-                .textResId(R.string.pop_notification_text)
-                .colorResId(R.color.colorPrimary)
-                .notificationId(1021)
-                .build();
-        final PopConfig popConfig = new PopConfig.Builder(context, UNIT_ID_POP)
-                .initialSidePosition(new SidePosition(SidePosition.Side.RIGHT, 0.6f))
-                .initialPopIdleMode(PopConfig.PopIdleMode.INVISIBLE)
-                .feedConfig(feedConfig)
-                .popNotificationConfig(popNotificationConfig)
-                .previewIntervalInMillis(1000) // for test
-                .build();
-
-        final BuzzAdBenefitConfig buzzAdBenefitConfig = new BuzzAdBenefitConfig.Builder(context)
-                .add(popConfig)
-                .build();
-        BuzzAdBenefit.init(context, buzzAdBenefitConfig);
-    }
-
-    /**
-     * [CUSTOM_POP_CONTROL_SERVICE] Set custom PopControlService
-     */
-    private void initBuzzAdBenefitWithCustomControlService() {
-        final PopNotificationConfig popNotificationConfig = new PopNotificationConfig.Builder(context)
-                .smallIconResId(R.drawable.ic_notification_pop_gift)
-                .notificationId(1021)
-                .build();
-
-        final PopConfig popConfig = new PopConfig.Builder(context, UNIT_ID_POP)
-                .initialSidePosition(new SidePosition(SidePosition.Side.RIGHT, 0.6f))
-                .initialPopIdleMode(PopConfig.PopIdleMode.INVISIBLE)
-                .controlService(CustomControlService.class)
-                .popNotificationConfig(popNotificationConfig)
-                .build();
-
-        final BuzzAdBenefitConfig buzzAdBenefitConfig = new BuzzAdBenefitConfig.Builder(context)
-                .add(popConfig)
-                .build();
-        BuzzAdBenefit.init(context, buzzAdBenefitConfig);
     }
 }

--- a/buzzad-benefit-pop/app/src/main/java/com/buzzvil/buzzad/benefit/popsample/java/BuzzAdPopController.java
+++ b/buzzad-benefit-pop/app/src/main/java/com/buzzvil/buzzad/benefit/popsample/java/BuzzAdPopController.java
@@ -17,8 +17,7 @@ import com.buzzvil.buzzad.benefit.presentation.feed.FeedConfig;
 
 public class BuzzAdPopController {
     public static final String TAG = "App";
-    public static final String BUZZ_AD_PREFERENCE = "BUZZ_AD_PREFERENCE";
-    public static final String POP_ENABLED = "popInitialized";
+    public static final String BUZZ_AD_BENEFIT_ENABLED = "popInitialized";
     public static final String UNIT_ID_POP = "236027834764095";
     public boolean isBuzzAdBenefitInitialized = false;
     private BuzzAdPop buzzAdPop = null;
@@ -30,15 +29,23 @@ public class BuzzAdPopController {
         this.sharedPref = sharedPref;
     }
 
-    public void clearBuzzAdBenefit() {
-        Log.d(TAG, "clearBuzzAdBenefit");
-        isBuzzAdBenefitInitialized = false;
-        buzzAdPop.removePop(context);
-        buzzAdPop = null;
-        sharedPref.edit().putBoolean(POP_ENABLED, false).apply();
+    public boolean isBuzzAdBenefitEnabled() {
+        return sharedPref.getBoolean(BUZZ_AD_BENEFIT_ENABLED, false);
     }
 
-    public void buildBuzzAdPop() {
+    public void clearBuzzAdBenefit() {
+        Log.d(TAG, "clearBuzzAdBenefit");
+        if (buzzAdPop != null) {
+            isBuzzAdBenefitInitialized = false;
+            buzzAdPop.removePop(context);
+            buzzAdPop = null;
+            sharedPref.edit().putBoolean(BUZZ_AD_BENEFIT_ENABLED, false).apply();
+        } else {
+            Log.d(TAG, "clearBuzzAdBenefit fail, buzzAdPop is null");
+        }
+    }
+
+    public void buildBuzzAdPop() throws IllegalStateException {
         if (isBuzzAdBenefitInitialized && buzzAdPop == null) {
             Log.d(TAG, "getBuzzAdPop success");
             buzzAdPop = new BuzzAdPop(context, App.UNIT_ID_POP);
@@ -82,8 +89,8 @@ public class BuzzAdPopController {
                 .add(popConfig)
                 .build();
         BuzzAdBenefit.init(context, buzzAdBenefitConfig);
-        sharedPref.edit().putBoolean(POP_ENABLED, true).apply();
 
+        sharedPref.edit().putBoolean(BUZZ_AD_BENEFIT_ENABLED, true).apply();
         isBuzzAdBenefitInitialized = true;
     }
 }

--- a/buzzad-benefit-pop/app/src/main/java/com/buzzvil/buzzad/benefit/popsample/java/BuzzAdPopController.java
+++ b/buzzad-benefit-pop/app/src/main/java/com/buzzvil/buzzad/benefit/popsample/java/BuzzAdPopController.java
@@ -1,0 +1,145 @@
+package com.buzzvil.buzzad.benefit.popsample.java;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.util.Log;
+
+import com.buzzvil.buzzad.benefit.BuzzAdBenefit;
+import com.buzzvil.buzzad.benefit.BuzzAdBenefitConfig;
+import com.buzzvil.buzzad.benefit.pop.BuzzAdPop;
+import com.buzzvil.buzzad.benefit.pop.DefaultPopHeaderViewAdapter;
+import com.buzzvil.buzzad.benefit.pop.PopConfig;
+import com.buzzvil.buzzad.benefit.pop.PopNotificationConfig;
+import com.buzzvil.buzzad.benefit.pop.SidePosition;
+import com.buzzvil.buzzad.benefit.pop.toolbar.DefaultPopToolbarHolder;
+import com.buzzvil.buzzad.benefit.popsample.R;
+import com.buzzvil.buzzad.benefit.popsample.java.custom.CustomControlService;
+import com.buzzvil.buzzad.benefit.popsample.java.custom.CustomPopHeaderViewAdapter;
+import com.buzzvil.buzzad.benefit.popsample.java.custom.CustomPopToolbarHolder;
+import com.buzzvil.buzzad.benefit.presentation.feed.FeedConfig;
+
+public class BuzzAdPopController {
+    public static final String TAG = "App";
+    public static final String BUZZ_AD_PREFERENCE = "BUZZ_AD_PREFERENCE";
+    public static final String POP_ENABLED = "popInitialized";
+    public static final String UNIT_ID_POP = "236027834764095";
+    public boolean isBuzzAdBenefitInitialized = false;
+    private BuzzAdPop buzzAdPop = null;
+    private SharedPreferences sharedPref;
+    private Context context;
+
+    BuzzAdPopController(Context context, SharedPreferences sharedPref) {
+        this.context = context;
+        this.sharedPref = sharedPref;
+    }
+
+    public void clearBuzzAdBenefit() {
+        Log.d(TAG, "clearBuzzAdBenefit");
+        isBuzzAdBenefitInitialized = false;
+        buzzAdPop.removePop(context);
+        buzzAdPop = null;
+        sharedPref.edit().putBoolean(POP_ENABLED, false).apply();
+    }
+
+    public void buildBuzzAdPop() {
+        if (isBuzzAdBenefitInitialized && buzzAdPop == null) {
+            Log.d(TAG, "getBuzzAdPop success");
+            buzzAdPop = new BuzzAdPop(context, App.UNIT_ID_POP);
+        } else {
+            Log.d(TAG, "getBuzzAdPop is already initialized");
+        }
+    }
+
+    public BuzzAdPop getBuzzAdPop() {
+        return buzzAdPop;
+    }
+
+    public void initBuzzAdBenefit() {
+        Log.d(TAG, "initBuzzAdBenefit");
+        final FeedConfig feedConfig = new FeedConfig.Builder(context, UNIT_ID_POP)
+                // DefaultPopToolbarHolder: DefaultToolbar
+                // TemplatePopToolbarHolder: Minimum customize, pop feed icon, name, button
+                // CustomPopToolbarHolder: Use layout for toolbar
+                .feedToolbarHolderClass(CustomPopToolbarHolder.class)
+                .feedHeaderViewAdapterClass(DefaultPopHeaderViewAdapter.class)
+                .articlesEnabled(true)
+                .articleInAppLandingEnabled(true)
+                .build();
+        final PopNotificationConfig popNotificationConfig = new PopNotificationConfig.Builder(context)
+                .smallIconResId(R.drawable.ic_notification_pop_gift)
+                .titleResId(R.string.pop_notification_title)
+                .textResId(R.string.pop_notification_text)
+                .colorResId(R.color.colorPrimary)
+                .notificationId(1021)
+                .build();
+        final PopConfig popConfig = new PopConfig.Builder(context, UNIT_ID_POP)
+                .initialSidePosition(new SidePosition(SidePosition.Side.RIGHT, 0.6f))
+                .initialPopIdleMode(PopConfig.PopIdleMode.INVISIBLE)
+                .feedConfig(feedConfig)
+                .idleTimeInMillis(10_000)
+                .popNotificationConfig(popNotificationConfig)
+                .previewIntervalInMillis(1000) // for test
+                .build();
+
+        final BuzzAdBenefitConfig buzzAdBenefitConfig = new BuzzAdBenefitConfig.Builder(context)
+                .add(popConfig)
+                .build();
+        BuzzAdBenefit.init(context, buzzAdBenefitConfig);
+        sharedPref.edit().putBoolean(POP_ENABLED, true).apply();
+
+        isBuzzAdBenefitInitialized = true;
+    }
+
+    /**
+     * [CUSTOM_POP_HEADER_VIEW_ADAPTER] Set custom CustomPopHeaderViewAdapter
+     */
+    private void initBuzzAdBenefitWithCustomPopHeaderViewAdapter() {
+        final FeedConfig feedConfig = new FeedConfig.Builder(context, UNIT_ID_POP)
+                .feedToolbarHolderClass(DefaultPopToolbarHolder.class)
+                .feedHeaderViewAdapterClass(CustomPopHeaderViewAdapter.class)
+                .articlesEnabled(true)
+                .articleInAppLandingEnabled(true)
+                .build();
+        final PopNotificationConfig popNotificationConfig = new PopNotificationConfig.Builder(context)
+                .smallIconResId(R.drawable.ic_notification_pop_gift)
+                .titleResId(R.string.pop_notification_title)
+                .textResId(R.string.pop_notification_text)
+                .colorResId(R.color.colorPrimary)
+                .notificationId(1021)
+                .build();
+        final PopConfig popConfig = new PopConfig.Builder(context, UNIT_ID_POP)
+                .initialSidePosition(new SidePosition(SidePosition.Side.RIGHT, 0.6f))
+                .initialPopIdleMode(PopConfig.PopIdleMode.INVISIBLE)
+                .feedConfig(feedConfig)
+                .popNotificationConfig(popNotificationConfig)
+                .previewIntervalInMillis(1000) // for test
+                .build();
+
+        final BuzzAdBenefitConfig buzzAdBenefitConfig = new BuzzAdBenefitConfig.Builder(context)
+                .add(popConfig)
+                .build();
+        BuzzAdBenefit.init(context, buzzAdBenefitConfig);
+    }
+
+    /**
+     * [CUSTOM_POP_CONTROL_SERVICE] Set custom PopControlService
+     */
+    private void initBuzzAdBenefitWithCustomControlService() {
+        final PopNotificationConfig popNotificationConfig = new PopNotificationConfig.Builder(context)
+                .smallIconResId(R.drawable.ic_notification_pop_gift)
+                .notificationId(1021)
+                .build();
+
+        final PopConfig popConfig = new PopConfig.Builder(context, UNIT_ID_POP)
+                .initialSidePosition(new SidePosition(SidePosition.Side.RIGHT, 0.6f))
+                .initialPopIdleMode(PopConfig.PopIdleMode.INVISIBLE)
+                .controlService(CustomControlService.class)
+                .popNotificationConfig(popNotificationConfig)
+                .build();
+
+        final BuzzAdBenefitConfig buzzAdBenefitConfig = new BuzzAdBenefitConfig.Builder(context)
+                .add(popConfig)
+                .build();
+        BuzzAdBenefit.init(context, buzzAdBenefitConfig);
+    }
+}

--- a/buzzad-benefit-pop/app/src/main/java/com/buzzvil/buzzad/benefit/popsample/java/MainActivity.java
+++ b/buzzad-benefit-pop/app/src/main/java/com/buzzvil/buzzad/benefit/popsample/java/MainActivity.java
@@ -29,7 +29,7 @@ public class MainActivity extends AppCompatActivity {
     private final static int REQUEST_CODE_SHOW_POP = 100;
 
     private Button popInitButton;
-    private Button popLoginButton;
+    private Button popSetUserProfileButton;
     private Button popShowButton;
     private Button popUnregisterButton;
     private Button popClearButton;
@@ -55,20 +55,19 @@ public class MainActivity extends AppCompatActivity {
         popInitButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                if (!app.isBuzzAdBenefitInitialized()) {
-                    app.initBuzzAdBenefit();
-                }
+                app.initBuzzAdBenefit();
             }
         });
 
-        this.popLoginButton = findViewById(R.id.pop_set_user_profile_button);
-        popLoginButton.setOnClickListener(new View.OnClickListener() {
+        this.popSetUserProfileButton = findViewById(R.id.pop_set_user_profile_button);
+        popSetUserProfileButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
                 if (!app.isBuzzAdBenefitInitialized()) {
                     Toast.makeText(MainActivity.this, "buzzAdBenefit is not initialized. unable to set userProfile", Toast.LENGTH_SHORT).show();
                     return;
                 }
+                Log.d(TAG, "setUserProfile");
                 final UserProfile userProfile = new UserProfile.Builder(BuzzAdBenefit.getUserProfile())
                         .userId("SAMPLE_USER_ID")
                         .gender(UserProfile.Gender.FEMALE)

--- a/buzzad-benefit-pop/app/src/main/java/com/buzzvil/buzzad/benefit/popsample/java/MainActivity.java
+++ b/buzzad-benefit-pop/app/src/main/java/com/buzzvil/buzzad/benefit/popsample/java/MainActivity.java
@@ -46,13 +46,19 @@ public class MainActivity extends AppCompatActivity {
         }
     };
 
+    private App app;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
-        BuzzAdBenefit.registerSessionReadyBroadcastReceiver(MainActivity.this, sessionReadyReceiver);
+        app = (App) getApplication();
 
-        this.buzzAdPop = new BuzzAdPop(this, App.UNIT_ID_POP);
+        if (app.isBenefitInitialized) {
+            BuzzAdBenefit.registerSessionReadyBroadcastReceiver(MainActivity.this, sessionReadyReceiver);
+            this.buzzAdPop = new BuzzAdPop(this, App.UNIT_ID_POP);
+        }
+
         this.popShowButton = findViewById(R.id.pop_show_button);
         popShowButton.setOnClickListener(new View.OnClickListener() {
             @Override
@@ -73,6 +79,10 @@ public class MainActivity extends AppCompatActivity {
         popUnregisterButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
+                if (buzzAdPop == null) {
+                    Toast.makeText(MainActivity.this, "buzzAdPop is not ready. unable to unregister pop", Toast.LENGTH_SHORT).show();
+                    return;
+                }
                 buzzAdPop.removePop(MainActivity.this);
             }
         });
@@ -80,7 +90,11 @@ public class MainActivity extends AppCompatActivity {
         if (getIntent().getBooleanExtra(KEY_SETTINGS_RESULT, false)
                 && getIntent().getIntExtra(KEY_SETTINGS_REQUEST_CODE, 0) == REQUEST_CODE_SHOW_POP) {
             if (BuzzAdPop.hasPermission(this)) {
-                buzzAdPop.showTutorialPopup(this);
+                if (buzzAdPop != null) {
+                    buzzAdPop.showTutorialPopup(this);
+                } else {
+                    Toast.makeText(MainActivity.this, "buzzAdPop is not ready. unable to showTutorialPop", Toast.LENGTH_SHORT).show();
+                }
                 // overlay permission granted
                 // collect event here if necessary
             }
@@ -88,6 +102,10 @@ public class MainActivity extends AppCompatActivity {
     }
 
     private void showPopOrRequestPermissionWithDialog() {
+        if (buzzAdPop == null) {
+            Toast.makeText(MainActivity.this, "buzzAdPop is not ready. unable to showPop", Toast.LENGTH_SHORT).show();
+            return;
+        }
         if (BuzzAdPop.hasPermission(MainActivity.this) || Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
             showPop();
         } else {
@@ -101,6 +119,10 @@ public class MainActivity extends AppCompatActivity {
     }
 
     private void showPop() {
+        if (buzzAdPop == null) {
+            Toast.makeText(MainActivity.this, "buzzAdPop is not ready. unable to showPop", Toast.LENGTH_SHORT).show();
+            return;
+        }
         buzzAdPop.preloadAndShowPop(MainActivity.this);
 
         // Use this instead of preloadAndShowPop if need to show pop tutorial dialog
@@ -112,6 +134,10 @@ public class MainActivity extends AppCompatActivity {
      * Use this method when collecting event for overlay permission granted, otherwise see showPopOrRequestPermissionWithDialog
      */
     private void showPopOrShowOverlayPermissionDialog() {
+        if (buzzAdPop == null) {
+            Toast.makeText(MainActivity.this, "buzzAdPop is not ready. unable to showPop", Toast.LENGTH_SHORT).show();
+            return;
+        }
         if (BuzzAdPop.hasPermission(MainActivity.this) || Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
             showPop();
         } else {

--- a/buzzad-benefit-pop/app/src/main/java/com/buzzvil/buzzad/benefit/popsample/java/MainActivity.java
+++ b/buzzad-benefit-pop/app/src/main/java/com/buzzvil/buzzad/benefit/popsample/java/MainActivity.java
@@ -62,7 +62,7 @@ public class MainActivity extends AppCompatActivity {
         popInitButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                if (!app.isBuzzAdBenefitInitialized) {
+                if (!app.isBuzzAdBenefitInitialized()) {
                     app.initBuzzAdBenefit();
                 }
             }
@@ -72,7 +72,7 @@ public class MainActivity extends AppCompatActivity {
         popLoginButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                if (!app.isBuzzAdBenefitInitialized) {
+                if (!app.isBuzzAdBenefitInitialized()) {
                     Toast.makeText(MainActivity.this, "buzzAdBenefit is not initialized. unable to set userProfile", Toast.LENGTH_SHORT).show();
                     return;
                 }
@@ -122,7 +122,7 @@ public class MainActivity extends AppCompatActivity {
                     Toast.makeText(MainActivity.this, "buzzAdPop is not ready. No need to clear", Toast.LENGTH_SHORT).show();
                     return;
                 }
-                if (!app.isBuzzAdBenefitInitialized) {
+                if (!app.isBuzzAdBenefitInitialized()) {
                     Log.d(TAG, "BuzzAdPop is not initialized. No need to clear");
                     return;
                 }

--- a/buzzad-benefit-pop/app/src/main/java/com/buzzvil/buzzad/benefit/popsample/java/MainActivity.java
+++ b/buzzad-benefit-pop/app/src/main/java/com/buzzvil/buzzad/benefit/popsample/java/MainActivity.java
@@ -8,6 +8,7 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.Handler;
 import android.util.Log;
 import android.view.View;
 import android.widget.Button;
@@ -39,14 +40,12 @@ public class MainActivity extends AppCompatActivity {
     private Button popUnregisterButton;
     private Button popShowWithCustomPermissoinDialogButton;
     private Button popClearButton;
-
-    private BuzzAdPop buzzAdPop;
     private BroadcastReceiver sessionReadyReceiver = new BroadcastReceiver() {
         @Override
         public void onReceive(Context context, Intent intent) {
             Log.e("SessionKey", "Session is Ready. Ads can be loaded now.");
             Toast.makeText(MainActivity.this, "Session is Ready. Ads can be loaded now.", Toast.LENGTH_SHORT).show();
-            buildBuzzAdPop();
+            app.buildBuzzAdPop();
         }
     };
 
@@ -58,7 +57,7 @@ public class MainActivity extends AppCompatActivity {
         setContentView(R.layout.activity_main);
         app = (App) getApplication();
 
-        buildBuzzAdPop();
+        app.buildBuzzAdPop();
         this.popInitButton = findViewById(R.id.pop_init_button);
         popInitButton.setOnClickListener(new View.OnClickListener() {
             @Override
@@ -107,11 +106,11 @@ public class MainActivity extends AppCompatActivity {
         popUnregisterButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                if (buzzAdPop == null) {
+                if (app.getBuzzAdPop() == null) {
                     Toast.makeText(MainActivity.this, "buzzAdPop is not ready. unable to unregister pop", Toast.LENGTH_SHORT).show();
                     return;
                 }
-                buzzAdPop.removePop(MainActivity.this);
+                app.getBuzzAdPop().removePop(MainActivity.this);
             }
         });
 
@@ -119,24 +118,29 @@ public class MainActivity extends AppCompatActivity {
         popClearButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                if (buzzAdPop == null) {
-                    Toast.makeText(MainActivity.this, "buzzAdPop is not ready. unable to unregister pop", Toast.LENGTH_SHORT).show();
+                if (app.getBuzzAdPop() == null) {
+                    Toast.makeText(MainActivity.this, "buzzAdPop is not ready. No need to clear", Toast.LENGTH_SHORT).show();
                     return;
                 }
                 if (!app.isBuzzAdBenefitInitialized) {
                     Log.d(TAG, "BuzzAdPop is not initialized. No need to clear");
                     return;
                 }
-                buzzAdPop.removePop(MainActivity.this);
-                app.clearBuzzAdBenefit();
+
+                new Handler().postDelayed(new Runnable() {
+                    @Override
+                    public void run() {
+                        app.clearBuzzAdBenefit();
+                    }
+                }, 2000);
             }
         });
 
         if (getIntent().getBooleanExtra(KEY_SETTINGS_RESULT, false)
                 && getIntent().getIntExtra(KEY_SETTINGS_REQUEST_CODE, 0) == REQUEST_CODE_SHOW_POP) {
             if (BuzzAdPop.hasPermission(this)) {
-                if (buzzAdPop != null) {
-                    buzzAdPop.showTutorialPopup(this);
+                if (app.getBuzzAdPop() != null) {
+                    app.getBuzzAdPop().showTutorialPopup(this);
                 } else {
                     Toast.makeText(MainActivity.this, "buzzAdPop is not ready. unable to showTutorialPop", Toast.LENGTH_SHORT).show();
                     Log.d(TAG, "buzzAdPop is not ready. unable to showTutorialPop");
@@ -147,17 +151,17 @@ public class MainActivity extends AppCompatActivity {
         }
     }
 
-    private void buildBuzzAdPop() {
-        if (app.isBuzzAdBenefitInitialized && buzzAdPop == null) {
-            Log.d(TAG, "buildBuzzAdPop success");
-            buzzAdPop = new BuzzAdPop(MainActivity.this, App.UNIT_ID_POP);
-        } else {
-            Log.d(TAG, "buildBuzzAdPop is already initialized");
-        }
-    }
+//    private void buildBuzzAdPop() {
+//        if (app.isBuzzAdBenefitInitialized && buzzAdPop == null) {
+//            Log.d(TAG, "buildBuzzAdPop success");
+//            buzzAdPop = new BuzzAdPop(MainActivity.this, App.UNIT_ID_POP);
+//        } else {
+//            Log.d(TAG, "buildBuzzAdPop is already initialized");
+//        }
+//    }
 
     private void showPopOrRequestPermissionWithDialog() {
-        if (buzzAdPop == null) {
+        if (app.getBuzzAdPop() == null) {
             Toast.makeText(MainActivity.this, "buzzAdPop is not ready. unable to showPop", Toast.LENGTH_SHORT).show();
             Log.d(TAG, "buzzAdPop is not ready. unable to showPop");
             return;
@@ -175,12 +179,12 @@ public class MainActivity extends AppCompatActivity {
     }
 
     private void showPop() {
-        if (buzzAdPop == null) {
+        if (app.getBuzzAdPop() == null) {
             Toast.makeText(MainActivity.this, "buzzAdPop is not ready. unable to showPop", Toast.LENGTH_SHORT).show();
             Log.d(TAG, "buzzAdPop is not ready. unable to showPop");
             return;
         }
-        buzzAdPop.preloadAndShowPop(MainActivity.this);
+        app.getBuzzAdPop().preloadAndShowPop(MainActivity.this);
 
         // Use this instead of preloadAndShowPop if need to show pop tutorial dialog
         // buzzAdPop.showTutorialPopup(MainActivity.this);
@@ -191,7 +195,7 @@ public class MainActivity extends AppCompatActivity {
      * Use this method when collecting event for overlay permission granted, otherwise see showPopOrRequestPermissionWithDialog
      */
     private void showPopOrShowOverlayPermissionDialog() {
-        if (buzzAdPop == null) {
+        if (app.getBuzzAdPop() == null) {
             Toast.makeText(MainActivity.this, "buzzAdPop is not ready. unable to showPop", Toast.LENGTH_SHORT).show();
             Log.d(TAG, "buzzAdPop is not ready. unable to showPop");
             return;

--- a/buzzad-benefit-pop/app/src/main/java/com/buzzvil/buzzad/benefit/popsample/java/MainActivity.java
+++ b/buzzad-benefit-pop/app/src/main/java/com/buzzvil/buzzad/benefit/popsample/java/MainActivity.java
@@ -1,10 +1,7 @@
 package com.buzzvil.buzzad.benefit.popsample.java;
 
-import android.app.Activity;
-import android.app.AlertDialog;
 import android.content.BroadcastReceiver;
 import android.content.Context;
-import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
@@ -14,7 +11,6 @@ import android.view.View;
 import android.widget.Button;
 import android.widget.Toast;
 
-import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 
 import com.buzzvil.buzzad.benefit.BuzzAdBenefit;
@@ -22,8 +18,6 @@ import com.buzzvil.buzzad.benefit.core.models.UserProfile;
 import com.buzzvil.buzzad.benefit.pop.BuzzAdPop;
 import com.buzzvil.buzzad.benefit.pop.PopOverlayPermissionConfig;
 import com.buzzvil.buzzad.benefit.popsample.R;
-import com.buzzvil.lib.buzzsettingsmonitor.OverlaySettingsMonitor;
-import com.buzzvil.lib.buzzsettingsmonitor.SettingsMonitorManager;
 
 import io.mattcarroll.hover.overlay.OverlayPermission;
 
@@ -38,7 +32,6 @@ public class MainActivity extends AppCompatActivity {
     private Button popLoginButton;
     private Button popShowButton;
     private Button popUnregisterButton;
-    private Button popShowWithCustomPermissoinDialogButton;
     private Button popClearButton;
     private BroadcastReceiver sessionReadyReceiver = new BroadcastReceiver() {
         @Override
@@ -94,14 +87,6 @@ public class MainActivity extends AppCompatActivity {
             }
         });
 
-        this.popShowWithCustomPermissoinDialogButton = findViewById(R.id.pop_show_button_with_custom_permission_dialog_button);
-        popShowWithCustomPermissoinDialogButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                showPopOrShowOverlayPermissionDialog();
-            }
-        });
-
         this.popUnregisterButton = findViewById(R.id.pop_unregister_button);
         popUnregisterButton.setOnClickListener(new View.OnClickListener() {
             @Override
@@ -151,15 +136,6 @@ public class MainActivity extends AppCompatActivity {
         }
     }
 
-//    private void buildBuzzAdPop() {
-//        if (app.isBuzzAdBenefitInitialized && buzzAdPop == null) {
-//            Log.d(TAG, "buildBuzzAdPop success");
-//            buzzAdPop = new BuzzAdPop(MainActivity.this, App.UNIT_ID_POP);
-//        } else {
-//            Log.d(TAG, "buildBuzzAdPop is already initialized");
-//        }
-//    }
-
     private void showPopOrRequestPermissionWithDialog() {
         if (app.getBuzzAdPop() == null) {
             Toast.makeText(MainActivity.this, "buzzAdPop is not ready. unable to showPop", Toast.LENGTH_SHORT).show();
@@ -188,59 +164,6 @@ public class MainActivity extends AppCompatActivity {
 
         // Use this instead of preloadAndShowPop if need to show pop tutorial dialog
         // buzzAdPop.showTutorialPopup(MainActivity.this);
-    }
-
-    /*
-     * (Optional: CUSTOM PERMISSION DIALOG)
-     * Use this method when collecting event for overlay permission granted, otherwise see showPopOrRequestPermissionWithDialog
-     */
-    private void showPopOrShowOverlayPermissionDialog() {
-        if (app.getBuzzAdPop() == null) {
-            Toast.makeText(MainActivity.this, "buzzAdPop is not ready. unable to showPop", Toast.LENGTH_SHORT).show();
-            Log.d(TAG, "buzzAdPop is not ready. unable to showPop");
-            return;
-        }
-        if (BuzzAdPop.hasPermission(MainActivity.this) || Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
-            showPop();
-        } else {
-            showPopOverlayPermissionDialog(MainActivity.this, new PopOverlayPermissionConfig.Builder(R.string.pop_name)
-                    .settingsIntent(OverlayPermission.createIntentToRequestOverlayPermission(MainActivity.this))
-                    .requestCode(REQUEST_CODE_SHOW_POP)
-                    .build());
-
-        }
-    }
-
-    /*
-     * (Optional: CUSTOM PERMISSION DIALOG)
-     * Use this method when collecting event for overlay permission granted, otherwise see showPopOrRequestPermissionWithDialog
-     */
-    private void showPopOverlayPermissionDialog(@NonNull final Activity activity, @NonNull final PopOverlayPermissionConfig permissionSettings) {
-        final AlertDialog dialog = new AlertDialog.Builder(activity)
-                .setTitle(permissionSettings.getTitle())
-                .setPositiveButton(permissionSettings.getPositiveButtonText(), new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int which) {
-                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                            new SettingsMonitorManager().openSettingsActivity(
-                                    new OverlaySettingsMonitor(activity, activity.getClass(), permissionSettings.getRequestCode()),
-                                    activity,
-                                    permissionSettings.getSettingsIntent());
-                            dialog.dismiss();
-                        } else {
-                            Log.e(TAG, "Unnecessary to show showPopOverlayPermissionDialog for this android os version");
-                        }
-                    }
-                })
-                .setNegativeButton(permissionSettings.getNegativeButtonText(), new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int which) {
-                        dialog.dismiss();
-                    }
-                })
-                .setCancelable(true)
-                .create();
-        dialog.show();
     }
 
     @Override

--- a/buzzad-benefit-pop/app/src/main/res/layout/activity_main.xml
+++ b/buzzad-benefit-pop/app/src/main/res/layout/activity_main.xml
@@ -17,6 +17,18 @@
             android:orientation="vertical">
 
             <Button
+                android:id="@+id/pop_init_button"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Init" />
+
+            <Button
+                android:id="@+id/pop_set_user_profile_button"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Set UserProfile" />
+
+            <Button
                 android:id="@+id/pop_show_button"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -34,6 +46,12 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="Unregister pop" />
+
+            <Button
+                android:id="@+id/pop_clear_pop"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Clear Pop" />
 
         </LinearLayout>
 

--- a/buzzad-benefit-pop/app/src/main/res/layout/activity_main.xml
+++ b/buzzad-benefit-pop/app/src/main/res/layout/activity_main.xml
@@ -34,13 +34,6 @@
                 android:layout_height="wrap_content"
                 android:text="Show pop" />
 
-            <!-- Optional: CUSTOM PERMISSION DIALOG-->
-            <Button
-                android:id="@+id/pop_show_button_with_custom_permission_dialog_button"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="(Optional) Show pop w/ custom permission dialog" />
-
             <Button
                 android:id="@+id/pop_unregister_button"
                 android:layout_width="match_parent"

--- a/buzzad-benefit-pop/build.gradle
+++ b/buzzad-benefit-pop/build.gradle
@@ -28,5 +28,5 @@ task clean(type: Delete) {
 }
 
 ext {
-    buzzAdBenefitVersionName = '2.5.+'
+    buzzAdBenefitVersionName = '2.7.+'
 }


### PR DESCRIPTION
### 이 PR 은 리뷰 용으로 merge 되지 않습니다.

- Application onCreate 에서 항상 BuzzAdBenefit 초기화하던 것을 유저가 동의(명시적 benefit enable) 한 후에만 초기화하도록 변경
- BuzzAdBenefitController 를 추가: BuzzAdBenefit 초기화 및 Pop enable 등을 컨트롤
- CustomDialog 관련 코드는 lazyInit 과 무관하므로 제거




