### PR TITLE
update buzz-pedometer-sdk to 1.2.5

### DIFF
--- a/buzz-pedometer/README.md
+++ b/buzz-pedometer/README.md
@@ -2,6 +2,11 @@
 
 * 개발 가이드: https://buzzvil.atlassian.net/l/c/fqq7qvvv
 
+# 1.2.5
+* [FIX] Android 10 이상에서 Activity recognition permission 받도록 수정
+* [FIX] 센서를 지원하지 않는 디바이스에서 토스트를 띄우도록 수정
+* 버그 수정
+
 # 1.1.2
 * [ADD] presentation layer model 난독화 예외 룰 추가
 * [FIX] 특정 동작 후 의도치 않게 스텝이 초기화되는 이슈 해결

--- a/buzz-pedometer/app/build.gradle
+++ b/buzz-pedometer/app/build.gradle
@@ -1,14 +1,14 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
 
     defaultConfig {
         applicationId "com.buzzvil.pedometer.sample"
         minSdkVersion 16
         targetSdkVersion 29
-        versionCode 124
-        versionName "1.2.4"
+        versionCode 125
+        versionName "1.2.5"
         multiDexEnabled true
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -30,5 +30,5 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 
     implementation 'androidx.multidex:multidex:2.0.1'
-    implementation 'com.buzzvil:buzz-pedometer-sdk:1.2.4'
+    implementation 'com.buzzvil:buzz-pedometer-sdk:1.2.5'
 }


### PR DESCRIPTION
Android Q 이상에서 Activity recognition permission을 받도록 수정하였고, 
STEP_COUNTER 센서를 지원하지 않는 디바이스에서는 activate시 토스트가 뜨도록 변경되었습니다.
