### PR TITLE
[PO-1203][FIX] Use AppId in manifest

### DIFF
--- a/buzzad-benefit-pop/app/src/pedometerpop/AndroidManifest.xml
+++ b/buzzad-benefit-pop/app/src/pedometerpop/AndroidManifest.xml
@@ -24,6 +24,9 @@
         <!-- [CUSTOM_POP_CONTROL_SERVICE] Only need to add this service when use custom pop control service, otherwise don't need to add this service -->
         <service android:name=".java.custom.CustomControlService" />
 
+        <meta-data
+            android:name="com.buzzvil.APP_KEY"
+            android:value="app-pub-260318561407891" />
     </application>
 
 </manifest>

--- a/buzzad-benefit-pop/app/src/pedometerpop/java/com/buzzvil/buzzad/benefit/popsample/java/App.java
+++ b/buzzad-benefit-pop/app/src/pedometerpop/java/com/buzzvil/buzzad/benefit/popsample/java/App.java
@@ -28,7 +28,6 @@ public class App extends MultiDexApplication {
 
     // Caution: Please replace IDs with your unit IDs.
     public static final String UNIT_ID_POP = "236027834764095";
-    public static final String APP_ID = "260318561407891";
     public static final String UNIT_ID_PEDOMETER = "450190159219814";
     public static final String UNIT_ID_PEDOMETER_REWARD = "153253018216976";
     public static final String UNIT_ID_PEDOMETER_INTRO = "304632571836222";
@@ -96,7 +95,7 @@ public class App extends MultiDexApplication {
             Log.d(TAG, "Session is Ready. initPedometer");
 
             if (popConfig.getPedometerConfig() != null) {
-                BuzzAdPopPedometer.init(context, APP_ID, UNIT_ID_POP);
+                BuzzAdPopPedometer.init(context, UNIT_ID_POP);
             }
         }
     };


### PR DESCRIPTION
popsample 에서 AppId를 변수로 선언하여 사용하고 있었습니다. 

AppId를 manifest로 옮겼고, BuzzAdPopPedometer 에서는 manifest 에서 직접 참조하여 사용할 것 입니다.
SDK 배포 후 머지하겠습니다.