### PR TITLE
Fix push compile

### DIFF
--- a/buzzad-benefit-push/app/src/main/java/com/buzzvil/buzzad/benefit/notiplussample/App.java
+++ b/buzzad-benefit-push/app/src/main/java/com/buzzvil/buzzad/benefit/notiplussample/App.java
@@ -10,7 +10,7 @@ import com.buzzvil.buzzad.benefit.presentation.notification.RewardNotificationCo
 
 public class App extends MultiDexApplication {
     // Caution: Replace `236027834764095` with Your Unit ID
-    public static final String UNIT_ID_NOTI_PLUS = "236027834764095";
+    public static final String UNIT_ID_FEED = "236027834764095";
     public static RewardNotificationConfig rewardNotificationConfig;
 
     @Override

--- a/buzzad-benefit-push/app/src/main/java/com/buzzvil/buzzad/benefit/notiplussample/CustomNotificationWorker.java
+++ b/buzzad-benefit-push/app/src/main/java/com/buzzvil/buzzad/benefit/notiplussample/CustomNotificationWorker.java
@@ -18,11 +18,11 @@ public class CustomNotificationWorker extends NotificationWorker {
     @Override
     @NonNull
     public NotificationConfig getNotificationConfig() {
-        final FeedConfig feedConfig = new FeedConfig.Builder(getApplicationContext(), App.UNIT_ID_NOTI_PLUS)
+        final FeedConfig feedConfig = new FeedConfig.Builder(getApplicationContext(), App.UNIT_ID_FEED)
                 .adsAdapterClass(CustomFeedAdsAdapter.class)
                 .closeToastEnabled(true)
                 .build();
-        return new NotificationConfig.Builder(App.UNIT_ID_NOTI_PLUS)
+        return new NotificationConfig.Builder(App.UNIT_ID_FEED)
                 .build();
     }
 }

--- a/buzzad-benefit-push/app/src/main/java/com/buzzvil/buzzad/benefit/notiplussample/CustomNotificationWorker.java
+++ b/buzzad-benefit-push/app/src/main/java/com/buzzvil/buzzad/benefit/notiplussample/CustomNotificationWorker.java
@@ -5,7 +5,6 @@ import android.content.Context;
 import androidx.annotation.NonNull;
 import androidx.work.WorkerParameters;
 
-import com.buzzvil.buzzad.benefit.presentation.feed.FeedActivity;
 import com.buzzvil.buzzad.benefit.presentation.feed.FeedConfig;
 import com.buzzvil.buzzad.benefit.presentation.notification.NotificationConfig;
 import com.buzzvil.buzzad.benefit.presentation.notification.NotificationWorker;
@@ -24,7 +23,6 @@ public class CustomNotificationWorker extends NotificationWorker {
                 .closeToastEnabled(true)
                 .build();
         return new NotificationConfig.Builder(App.UNIT_ID_NOTI_PLUS)
-                .putExtra(FeedActivity.EXTRA_CONFIG, feedConfig)
                 .build();
     }
 }

--- a/buzzad-benefit-push/app/src/main/java/com/buzzvil/buzzad/benefit/notiplussample/CustomNotificationWorker.java
+++ b/buzzad-benefit-push/app/src/main/java/com/buzzvil/buzzad/benefit/notiplussample/CustomNotificationWorker.java
@@ -18,10 +18,6 @@ public class CustomNotificationWorker extends NotificationWorker {
     @Override
     @NonNull
     public NotificationConfig getNotificationConfig() {
-        final FeedConfig feedConfig = new FeedConfig.Builder(getApplicationContext(), App.UNIT_ID_FEED)
-                .adsAdapterClass(CustomFeedAdsAdapter.class)
-                .closeToastEnabled(true)
-                .build();
         return new NotificationConfig.Builder(App.UNIT_ID_FEED)
                 .build();
     }

--- a/buzzad-benefit-push/app/src/main/java/com/buzzvil/buzzad/benefit/notiplussample/MainActivity.java
+++ b/buzzad-benefit-push/app/src/main/java/com/buzzvil/buzzad/benefit/notiplussample/MainActivity.java
@@ -190,7 +190,7 @@ public class MainActivity extends AppCompatActivity {
 
     private BuzzAdPush initBuzzAdPush() {
         return new BuzzAdPush(
-                App.UNIT_ID_NOTI_PLUS,
+                App.UNIT_ID_FEED,
                 CustomNotificationWorker.class,
                 App.getPushDialogConfig()
         );

--- a/buzzad-benefit-push/app/src/main/java/com/buzzvil/buzzad/benefit/notiplussample/RestartReceiver.java
+++ b/buzzad-benefit-push/app/src/main/java/com/buzzvil/buzzad/benefit/notiplussample/RestartReceiver.java
@@ -11,7 +11,7 @@ public class RestartReceiver extends BroadcastReceiver {
     public void onReceive(Context context, Intent intent) {
         if (Intent.ACTION_BOOT_COMPLETED.equals(intent.getAction())
                 || Intent.ACTION_MY_PACKAGE_REPLACED.equals(intent.getAction())) {
-            final BuzzAdPush buzzAdNoti = new BuzzAdPush(App.UNIT_ID_NOTI_PLUS, CustomNotificationWorker.class, App.getPushDialogConfig());
+            final BuzzAdPush buzzAdNoti = new BuzzAdPush(App.UNIT_ID_FEED, CustomNotificationWorker.class, App.getPushDialogConfig());
             buzzAdNoti.registerWorkerIfNeeded(context);
         }
     }


### PR DESCRIPTION
내부적으로 feed unit id를 이용하여 feed config를 조회하고 사용하고 있어서 put extra 부분이 필요없어졌습니다.
그리고 유닛아이디 이름이 노티플러스로 헷갈리는 것 같아서 UNIT_ID_FEED로 리네임했습니다.