### PR TITLE
[OUT-301][MINOR] Bump iOS BuzzAdBenefit SDK to 2.2.5

### DIFF
--- a/buzzad-benefit-ios/BABSample/AppDelegate.m
+++ b/buzzad-benefit-ios/BABSample/AppDelegate.m
@@ -17,11 +17,6 @@
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
   BABConfig *config = [[BABConfig alloc] initWithAppId:@"100000044" environment:BABEnvProduction logging:YES];
-  NSString *appGroupId = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"AppGroupId"];
-  if (appGroupId != nil) {
-    [config setEnableWidget:YES];
-    [config setAppGroupId:appGroupId];
-  }
   [BuzzAdBenefit initializeWithConfig:config];
 
   BABUserPreference *userPreference = [[BABUserPreference alloc] initWithAutoPlayType:BABVideoAutoPlayOnWifi];

--- a/buzzad-benefit-ios/BABSample/CarouselView.m
+++ b/buzzad-benefit-ios/BABSample/CarouselView.m
@@ -44,7 +44,12 @@ const int CarouselItemAdViewTag = 2222;
   UIView *container = [[NSBundle mainBundle] loadNibNamed:@"CarouselView" owner:self options:nil][0];
   [self addSubview:container];
   [container setTranslatesAutoresizingMaskIntoConstraints:NO];
-  [container bzEdgesToContainer:self];
+  [NSLayoutConstraint activateConstraints:@[
+    [container.widthAnchor constraintEqualToAnchor:self.widthAnchor],
+    [container.heightAnchor constraintEqualToAnchor:self.heightAnchor],
+    [container.topAnchor constraintEqualToAnchor:self.topAnchor],
+    [container.leadingAnchor constraintEqualToAnchor:self.leadingAnchor],
+  ]];
 
   [_collectionView registerClass:[UICollectionViewCell class] forCellWithReuseIdentifier:CarouselItemReuseIdentifier];
 

--- a/buzzad-benefit-ios/BABSample/CarouselView.m
+++ b/buzzad-benefit-ios/BABSample/CarouselView.m
@@ -44,7 +44,7 @@ const int CarouselItemAdViewTag = 2222;
   UIView *container = [[NSBundle mainBundle] loadNibNamed:@"CarouselView" owner:self options:nil][0];
   [self addSubview:container];
   [container setTranslatesAutoresizingMaskIntoConstraints:NO];
-  [container edgesToContainer:self];
+  [container bzEdgesToContainer:self];
 
   [_collectionView registerClass:[UICollectionViewCell class] forCellWithReuseIdentifier:CarouselItemReuseIdentifier];
 

--- a/buzzad-benefit-ios/BABSample/WebViewController.m
+++ b/buzzad-benefit-ios/BABSample/WebViewController.m
@@ -1,7 +1,6 @@
 #import <WebKit/WebKit.h>
 #import "WebViewController.h"
 #import <BuzzAdBenefit/BuzzAdBenefit.h>
-#import <BuzzAdBenefitWebInterface/BuzzAdBenefitWebInterface.h>
 
 @interface WebViewController () <WKScriptMessageHandler> {
   WKWebView *_webView;

--- a/buzzad-benefit-ios/Podfile
+++ b/buzzad-benefit-ios/Podfile
@@ -4,9 +4,9 @@ use_frameworks!
 inhibit_all_warnings!
 
 target 'BABSample' do
-  pod 'BuzzAdBenefitFeed', '~> 2.2.4'
-  pod 'BuzzAdBenefitInterstitial', '~> 2.2.4'
-  pod 'BuzzAdBenefitNative', '~> 2.2.4'
+  pod 'BuzzAdBenefitFeed', '~> 2.2.5'
+  pod 'BuzzAdBenefitInterstitial', '~> 2.2.5'
+  pod 'BuzzAdBenefitNative', '~> 2.2.5'
   pod 'Toast', '~> 4.0.0'
 end
 

--- a/buzzad-benefit-ios/Podfile
+++ b/buzzad-benefit-ios/Podfile
@@ -1,10 +1,12 @@
-platform :ios, '9.0'
+platform :ios, '10.0'
 
 use_frameworks!
 inhibit_all_warnings!
 
 target 'BABSample' do
-  pod 'BuzzAdBenefit', '~> 2.0.0'
+  pod 'BuzzAdBenefitFeed', '~> 2.2.4'
+  pod 'BuzzAdBenefitInterstitial', '~> 2.2.4'
+  pod 'BuzzAdBenefitNative', '~> 2.2.4'
   pod 'Toast', '~> 4.0.0'
 end
 

--- a/buzzad-benefit-ios/Podfile.lock
+++ b/buzzad-benefit-ios/Podfile.lock
@@ -14,33 +14,73 @@ PODS:
   - AFNetworking/Serialization (4.0.1)
   - AFNetworking/UIKit (4.0.1):
     - AFNetworking/NSURLSession
-  - BuzzAdBenefit (2.0.0):
+  - BuzzAd (0.0.2):
+    - BuzzServiceApi (~> 0.0.6)
+    - ReactiveObjC (~> 3.1.1)
+  - BuzzAdBenefit (2.2.4):
     - AFNetworking (~> 4.0)
-    - GoogleAds-IMA-iOS-SDK (~> 3.11.3)
+    - BuzzAd (~> 0.0.2)
+    - BuzzBaseReward (~> 0.0.1)
+    - BuzzConfig (~> 0.0.3)
+    - BuzzInsight (~> 0.0.1)
+    - BuzzResource (~> 0.0.1)
+    - BuzzServiceApi (~> 0.0.6)
+    - BuzzUnit (~> 0.0.2)
+    - ReactiveObjC (~> 3.1.1)
+  - BuzzAdBenefitFeed (2.2.4):
+    - BuzzAdBenefit (~> 2.2.4)
+    - BuzzAdBenefitNative (~> 2.2.4)
+    - BuzzResource (~> 0.0.1)
     - ReactiveObjC (~> 3.1.1)
     - SDWebImage (~> 5.0)
     - SDWebImageWebPCoder
-  - GoogleAds-IMA-iOS-SDK (3.11.3)
-  - libwebp (1.1.0):
-    - libwebp/demux (= 1.1.0)
-    - libwebp/mux (= 1.1.0)
-    - libwebp/webp (= 1.1.0)
-  - libwebp/demux (1.1.0):
+  - BuzzAdBenefitInterstitial (2.2.4):
+    - BuzzAdBenefit (~> 2.2.4)
+    - BuzzAdBenefitNative (~> 2.2.4)
+  - BuzzAdBenefitNative (2.2.4):
+    - BuzzAdBenefit (~> 2.2.4)
+    - BuzzResource (~> 0.0.1)
+    - GoogleAds-IMA-iOS-SDK (~> 3.12)
+    - ReactiveObjC (~> 3.1.1)
+    - SDWebImage (~> 5.0)
+    - SDWebImageWebPCoder
+  - BuzzBaseReward (0.0.1):
+    - BuzzServiceApi (~> 0.0.6)
+    - ReactiveObjC (~> 3.1.1)
+  - BuzzConfig (0.0.3):
+    - BuzzServiceApi (~> 0.0.6)
+    - ReactiveObjC (~> 3.1.1)
+  - BuzzInsight (0.0.1):
+    - ReactiveObjC (~> 3.1.1)
+  - BuzzResource (0.0.1)
+  - BuzzServiceApi (0.0.6):
+    - ReactiveObjC (~> 3.1.1)
+  - BuzzUnit (0.0.2):
+    - BuzzServiceApi (~> 0.0.6)
+    - ReactiveObjC (~> 3.1.1)
+  - GoogleAds-IMA-iOS-SDK (3.14.3)
+  - libwebp (1.2.0):
+    - libwebp/demux (= 1.2.0)
+    - libwebp/mux (= 1.2.0)
+    - libwebp/webp (= 1.2.0)
+  - libwebp/demux (1.2.0):
     - libwebp/webp
-  - libwebp/mux (1.1.0):
+  - libwebp/mux (1.2.0):
     - libwebp/demux
-  - libwebp/webp (1.1.0)
+  - libwebp/webp (1.2.0)
   - ReactiveObjC (3.1.1)
-  - SDWebImage (5.9.1):
-    - SDWebImage/Core (= 5.9.1)
-  - SDWebImage/Core (5.9.1)
-  - SDWebImageWebPCoder (0.6.1):
+  - SDWebImage (5.11.1):
+    - SDWebImage/Core (= 5.11.1)
+  - SDWebImage/Core (5.11.1)
+  - SDWebImageWebPCoder (0.8.4):
     - libwebp (~> 1.0)
-    - SDWebImage/Core (~> 5.7)
+    - SDWebImage/Core (~> 5.10)
   - Toast (4.0.0)
 
 DEPENDENCIES:
-  - BuzzAdBenefit (~> 2.0.0)
+  - BuzzAdBenefitFeed (~> 2.2.4)
+  - BuzzAdBenefitInterstitial (~> 2.2.4)
+  - BuzzAdBenefitNative (~> 2.2.4)
   - Toast (~> 4.0.0)
 
 SPEC REPOS:
@@ -48,7 +88,17 @@ SPEC REPOS:
     - Toast
   trunk:
     - AFNetworking
+    - BuzzAd
     - BuzzAdBenefit
+    - BuzzAdBenefitFeed
+    - BuzzAdBenefitInterstitial
+    - BuzzAdBenefitNative
+    - BuzzBaseReward
+    - BuzzConfig
+    - BuzzInsight
+    - BuzzResource
+    - BuzzServiceApi
+    - BuzzUnit
     - GoogleAds-IMA-iOS-SDK
     - libwebp
     - ReactiveObjC
@@ -57,14 +107,24 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   AFNetworking: 7864c38297c79aaca1500c33288e429c3451fdce
-  BuzzAdBenefit: 9163d20b7cd40226aecf06ec48c110a209a22806
-  GoogleAds-IMA-iOS-SDK: 134b35758455576aaa6b3d2d3146699dcf8af4f1
-  libwebp: 946cb3063cea9236285f7e9a8505d806d30e07f3
+  BuzzAd: c0bc564a4f0083d623a2e10055192c00368c05f5
+  BuzzAdBenefit: a74426a719065cba81b6783514315d92b64a38b6
+  BuzzAdBenefitFeed: 040b0eeb8fc8abfb7a6e082f7307288814b63ccf
+  BuzzAdBenefitInterstitial: 2853a17617064ec53988768fed48da075d23004f
+  BuzzAdBenefitNative: 1231571b51160d7d5086140cf4d465e12a2e11a8
+  BuzzBaseReward: 64832b728da9912065f7b822d734945825e1a5eb
+  BuzzConfig: ee57d636a0ac135f391f4251c714538ab059d9d5
+  BuzzInsight: 1afd83069a56b7895b501d8257b620b1f72b3849
+  BuzzResource: 445770ba084ea7bcffbf9b1e24b7bcf0f4864f6a
+  BuzzServiceApi: 4812e1dfc9e836e6666497c902fa9f2963a0dece
+  BuzzUnit: 08c932a16a70ab9e71364e27b3afc697fb5f4715
+  GoogleAds-IMA-iOS-SDK: 2a9b7b14bda4993306f05287f952dce41b5be4ad
+  libwebp: e90b9c01d99205d03b6bb8f2c8c415e5a4ef66f0
   ReactiveObjC: 011caa393aa0383245f2dcf9bf02e86b80b36040
-  SDWebImage: a990c053fff71e388a10f3357edb0be17929c9c5
-  SDWebImageWebPCoder: d0dac55073088d24b2ac1b191a71a8f8d0adac21
+  SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d
+  SDWebImageWebPCoder: f93010f3f6c031e2f8fb3081ca4ee6966c539815
   Toast: 91b396c56ee72a5790816f40d3a94dd357abc196
 
-PODFILE CHECKSUM: d9fbb3eda74a53a13e091d8edf89f9173c9b8c6d
+PODFILE CHECKSUM: b7772ac54ba794bbab91228a196f7aee97aacc40
 
-COCOAPODS: 1.9.3
+COCOAPODS: 1.10.1

--- a/buzzad-benefit-ios/Podfile.lock
+++ b/buzzad-benefit-ios/Podfile.lock
@@ -17,7 +17,7 @@ PODS:
   - BuzzAd (0.0.2):
     - BuzzServiceApi (~> 0.0.6)
     - ReactiveObjC (~> 3.1.1)
-  - BuzzAdBenefit (2.2.4):
+  - BuzzAdBenefit (2.2.5):
     - AFNetworking (~> 4.0)
     - BuzzAd (~> 0.0.2)
     - BuzzBaseReward (~> 0.0.1)
@@ -27,18 +27,18 @@ PODS:
     - BuzzServiceApi (~> 0.0.6)
     - BuzzUnit (~> 0.0.2)
     - ReactiveObjC (~> 3.1.1)
-  - BuzzAdBenefitFeed (2.2.4):
-    - BuzzAdBenefit (~> 2.2.4)
-    - BuzzAdBenefitNative (~> 2.2.4)
+  - BuzzAdBenefitFeed (2.2.5):
+    - BuzzAdBenefit (~> 2.2.5)
+    - BuzzAdBenefitNative (~> 2.2.5)
     - BuzzResource (~> 0.0.1)
     - ReactiveObjC (~> 3.1.1)
     - SDWebImage (~> 5.0)
     - SDWebImageWebPCoder
-  - BuzzAdBenefitInterstitial (2.2.4):
-    - BuzzAdBenefit (~> 2.2.4)
-    - BuzzAdBenefitNative (~> 2.2.4)
-  - BuzzAdBenefitNative (2.2.4):
-    - BuzzAdBenefit (~> 2.2.4)
+  - BuzzAdBenefitInterstitial (2.2.5):
+    - BuzzAdBenefit (~> 2.2.5)
+    - BuzzAdBenefitNative (~> 2.2.5)
+  - BuzzAdBenefitNative (2.2.5):
+    - BuzzAdBenefit (~> 2.2.5)
     - BuzzResource (~> 0.0.1)
     - GoogleAds-IMA-iOS-SDK (~> 3.12)
     - ReactiveObjC (~> 3.1.1)
@@ -78,9 +78,9 @@ PODS:
   - Toast (4.0.0)
 
 DEPENDENCIES:
-  - BuzzAdBenefitFeed (~> 2.2.4)
-  - BuzzAdBenefitInterstitial (~> 2.2.4)
-  - BuzzAdBenefitNative (~> 2.2.4)
+  - BuzzAdBenefitFeed (~> 2.2.5)
+  - BuzzAdBenefitInterstitial (~> 2.2.5)
+  - BuzzAdBenefitNative (~> 2.2.5)
   - Toast (~> 4.0.0)
 
 SPEC REPOS:
@@ -108,10 +108,10 @@ SPEC REPOS:
 SPEC CHECKSUMS:
   AFNetworking: 7864c38297c79aaca1500c33288e429c3451fdce
   BuzzAd: c0bc564a4f0083d623a2e10055192c00368c05f5
-  BuzzAdBenefit: a74426a719065cba81b6783514315d92b64a38b6
-  BuzzAdBenefitFeed: 040b0eeb8fc8abfb7a6e082f7307288814b63ccf
-  BuzzAdBenefitInterstitial: 2853a17617064ec53988768fed48da075d23004f
-  BuzzAdBenefitNative: 1231571b51160d7d5086140cf4d465e12a2e11a8
+  BuzzAdBenefit: 70ef03c8fc5552a35147e07f991b2f67df0b2e28
+  BuzzAdBenefitFeed: 9391a13692048143e69bf38dc0cc816e7f9853c0
+  BuzzAdBenefitInterstitial: 0863940b774b2135cc6542535254c745075158c2
+  BuzzAdBenefitNative: e4a7ff9bd73b4fa1ec2ee4ee0aa3eaa55be7a146
   BuzzBaseReward: 64832b728da9912065f7b822d734945825e1a5eb
   BuzzConfig: ee57d636a0ac135f391f4251c714538ab059d9d5
   BuzzInsight: 1afd83069a56b7895b501d8257b620b1f72b3849
@@ -125,6 +125,6 @@ SPEC CHECKSUMS:
   SDWebImageWebPCoder: f93010f3f6c031e2f8fb3081ca4ee6966c539815
   Toast: 91b396c56ee72a5790816f40d3a94dd357abc196
 
-PODFILE CHECKSUM: b7772ac54ba794bbab91228a196f7aee97aacc40
+PODFILE CHECKSUM: a5ea0f302bc7f767ecc10350e2e8b71b03203de3
 
 COCOAPODS: 1.10.1


### PR DESCRIPTION
iOS 퍼블릭 샘플의 버전을 2.2.5로 업데이트 합니다.