### PR TITLE
BuzzAd iOS SDK 샘플 코드 오류 수정

### DIFF
--- a/buzzad-benefit-ios/BABSample/Feed/CustomFeedAdViewHolder.m
+++ b/buzzad-benefit-ios/BABSample/Feed/CustomFeedAdViewHolder.m
@@ -11,6 +11,7 @@
 @property (nonatomic, strong, readonly) UILabel *titleLabel;
 @property (nonatomic, strong, readonly) UILabel *descriptionLabel;
 @property (nonatomic, strong, readonly) CustomCtaView *ctaView;
+@property (nonatomic, strong, readonly) BZVNativeAdViewBinder *viewBinder;
 
 @end
 
@@ -31,15 +32,7 @@
 }
 
 - (void)renderAd:(BZVNativeAd *)ad {
-  BZVNativeAdViewBinder *viewBinder = [BZVNativeAdViewBinder viewBinderWithBlock:^(BZVNativeAdViewBinderBuilder * _Nonnull builder) {
-    builder.nativeAdView = self.nativeAdView;
-    builder.mediaView = self.mediaView;
-    builder.iconImageView = self.iconImageView;
-    builder.titleLabel = self.titleLabel;
-    builder.descriptionLabel = self.descriptionLabel;
-    builder.ctaView = self.ctaView;
-  }];
-  [viewBinder bindWithNativeAd:ad];
+  [_viewBinder bindWithNativeAd:ad];
   [ad addNativeAdEventDelegate:self];
 }
 
@@ -78,6 +71,15 @@
 
   _ctaView = [[CustomCtaView alloc] initWithFrame:CGRectZero];
   [_nativeAdView addSubview:_ctaView];
+  
+  _viewBinder = [BZVNativeAdViewBinder viewBinderWithBlock:^(BZVNativeAdViewBinderBuilder * _Nonnull builder) {
+    builder.nativeAdView = self.nativeAdView;
+    builder.mediaView = self.mediaView;
+    builder.iconImageView = self.iconImageView;
+    builder.titleLabel = self.titleLabel;
+    builder.descriptionLabel = self.descriptionLabel;
+    builder.ctaView = self.ctaView;
+  }];
 
   // LayoutConstraint 설정
   _nativeAdView.translatesAutoresizingMaskIntoConstraints = NO;

--- a/buzzad-benefit-ios/BABSample/Feed/CustomFeedCpsAdViewHolder.m
+++ b/buzzad-benefit-ios/BABSample/Feed/CustomFeedCpsAdViewHolder.m
@@ -14,6 +14,7 @@
 @property (nonatomic, strong, readonly) UILabel *priceLabel;
 @property (nonatomic, strong, readonly) UILabel *originalPriceLabel;
 @property (nonatomic, strong, readonly) UILabel *discountRateLabel;
+@property (nonatomic, strong, readonly) BZVNativeAdViewBinder *viewBinder;
 
 @end
 
@@ -34,21 +35,7 @@
 }
 
 - (void)renderAd:(BZVNativeAd *)ad {
-  BZVNativeAdViewBinder *viewBinder = [BZVNativeAdViewBinder viewBinderWithBlock:^(BZVNativeAdViewBinderBuilder * _Nonnull builder) {
-    builder.nativeAdView = self.nativeAdView;
-    builder.mediaView = self.mediaView;
-    builder.titleLabel = self.titleLabel;
-    builder.ctaView = self.ctaView;
-    // 부가 기능: 뷰를 클릭할 수 있도록 설정합니다.
-    builder.clickableViews = @[
-      self.mediaView,
-      self.priceLabel,
-      self.originalPriceLabel,
-      self.discountRateLabel,
-      self.ctaView,
-    ];
-  }];
-  [viewBinder bindWithNativeAd:ad];
+  [_viewBinder bindWithNativeAd:ad];
 
   BZVNativeAdProduct *product = ad.product;
   if (product.discountedPrice != 0) {
@@ -101,6 +88,21 @@
   _discountRateLabel = [[UILabel alloc] initWithFrame:CGRectZero];
   [_nativeAdView addSubview:_discountRateLabel];
 
+  _viewBinder = [BZVNativeAdViewBinder viewBinderWithBlock:^(BZVNativeAdViewBinderBuilder * _Nonnull builder) {
+    builder.nativeAdView = self.nativeAdView;
+    builder.mediaView = self.mediaView;
+    builder.titleLabel = self.titleLabel;
+    builder.ctaView = self.ctaView;
+    // 부가 기능: 뷰를 클릭할 수 있도록 설정합니다.
+    builder.clickableViews = @[
+      self.mediaView,
+      self.priceLabel,
+      self.originalPriceLabel,
+      self.discountRateLabel,
+      self.ctaView,
+    ];
+  }];
+  
   // LayoutConstraint 설정
   _nativeAdView.translatesAutoresizingMaskIntoConstraints = NO;
   [NSLayoutConstraint activateConstraints:@[

--- a/buzzad-benefit-ios/BABSample/Native/NativeViewController.m
+++ b/buzzad-benefit-ios/BABSample/Native/NativeViewController.m
@@ -18,6 +18,7 @@ static NSString * const kNavigationItemTitle = @"Native";
 @property (nonatomic, strong, readonly) UILabel *titleLabel;
 @property (nonatomic, strong, readonly) UILabel *descriptionLabel;
 @property (nonatomic, strong, readonly) CustomCtaView *ctaView;
+@property (nonatomic, strong, readonly) BZVNativeAdViewBinder *viewBinder;
 
 @end
 
@@ -44,15 +45,7 @@ static NSString * const kNavigationItemTitle = @"Native";
 }
 
 - (void)renderAd:(BZVNativeAd *)ad {
-  BZVNativeAdViewBinder *viewBinder = [BZVNativeAdViewBinder viewBinderWithBlock:^(BZVNativeAdViewBinderBuilder * _Nonnull builder) {
-    builder.nativeAdView = self.nativeAdView;
-    builder.mediaView = self.mediaView;
-    builder.iconImageView = self.iconImageView;
-    builder.titleLabel = self.titleLabel;
-    builder.descriptionLabel = self.descriptionLabel;
-    builder.ctaView = self.ctaView;
-  }];
-  [viewBinder bindWithNativeAd:ad];
+  [_viewBinder bindWithNativeAd:ad];
 
   // Optional: Native 광고 이벤트 처리를 위한 delegate을 등록하고 각 이벤트에 따라 필요한 기능을 구현합니다.
   // 주의: 반드시 bindWithNativeAd 함수를 호출한 이후에 리스너 등록을 해야합니다.
@@ -142,6 +135,15 @@ static NSString * const kNavigationItemTitle = @"Native";
 
   _ctaView = [[CustomCtaView alloc] initWithFrame:CGRectZero];
   [_nativeAdView addSubview:_ctaView];
+  
+  _viewBinder = [BZVNativeAdViewBinder viewBinderWithBlock:^(BZVNativeAdViewBinderBuilder * _Nonnull builder) {
+    builder.nativeAdView = self.nativeAdView;
+    builder.mediaView = self.mediaView;
+    builder.iconImageView = self.iconImageView;
+    builder.titleLabel = self.titleLabel;
+    builder.descriptionLabel = self.descriptionLabel;
+    builder.ctaView = self.ctaView;
+  }];
 
   // LayoutConstraint 설정
   _loadAdButton.translatesAutoresizingMaskIntoConstraints = NO;


### PR DESCRIPTION
샘플 코드를 잘못 작성한 부분을 수정했습니다. 광고를 렌더링 할 때 마다 `ViewBinder`를 매번 생성하는 코드를 `ViewBinder`를 한번만 생성하고 재사용하게 끔 변경했습니다.