### PR TITLE
[OUT-1645] BuzzAd JS SDK 1.3.1으로 업데이트

### DIFF
--- a/buzzad-benefit-web/web/index.html
+++ b/buzzad-benefit-web/web/index.html
@@ -96,7 +96,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.js"></script>
     <!-- end -->
 
-    <script src="https://buzz-js.buzzvil.com/buzzad-benefit-sdk/1.3.0/buzzad-benefit-sdk.js"></script>
+    <script src="https://buzz-js.buzzvil.com/buzzad-benefit-sdk/1.3.1/buzzad-benefit-sdk.js"></script>
     <script src="ids.js"></script>
     <script src="index.js"></script>
   </body>

--- a/buzzad-benefit-web/web/index.html
+++ b/buzzad-benefit-web/web/index.html
@@ -96,7 +96,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.js"></script>
     <!-- end -->
 
-    <script src="https://buzz-js.buzzvil.com/buzzad-benefit-sdk/1.2.3/buzzad-benefit-sdk.js"></script>
+    <script src="https://buzz-js.buzzvil.com/buzzad-benefit-sdk/1.3.0/buzzad-benefit-sdk.js"></script>
     <script src="ids.js"></script>
     <script src="index.js"></script>
   </body>


### PR DESCRIPTION
BuzzAd JS SDK에 Sentry를 끄는 옵션을 추가하여 새 버전인 1.3.1으로 배포하였습니다. 이에 따라 샘플 코드에서도 새 버전을 사용하도록 하였습니다.

원래는 1.3.0으로 배포할 계획이었으나, Sentry에 문제가 있어서 항상 끄는 걸로 기본값을 변경하면서 1.3.1로 새로 배포하였습니다.