### PR TITLE
BuzzAd iOS SDK 3.7.6

### DIFF
--- a/buzzad-benefit-ios/Podfile
+++ b/buzzad-benefit-ios/Podfile
@@ -1,14 +1,12 @@
 platform :ios, '10.0'
 
 source 'https://github.com/CocoaPods/Specs.git'
-# TODO: Remove after public deployment
-source 'https://github.com/Buzzvil/Specs.git'
 
 use_frameworks!
 inhibit_all_warnings!
 
 target 'BABSample' do
-  pod 'BuzzAdBenefit', '~> 3.7.5'
+  pod 'BuzzAdBenefit', '~> 3.7.6'
   pod 'Toast', '~> 4.0.0'
 end
 

--- a/buzzad-benefit-ios/Podfile
+++ b/buzzad-benefit-ios/Podfile
@@ -1,12 +1,14 @@
 platform :ios, '10.0'
 
 source 'https://github.com/CocoaPods/Specs.git'
+# TODO: Remove after public deployment
+source 'https://github.com/Buzzvil/Specs.git'
 
 use_frameworks!
 inhibit_all_warnings!
 
 target 'BABSample' do
-  pod 'BuzzAdBenefit', '~> 3.5.1'
+  pod 'BuzzAdBenefit', '~> 3.7.5'
   pod 'Toast', '~> 4.0.0'
 end
 

--- a/buzzad-benefit-ios/Podfile.lock
+++ b/buzzad-benefit-ios/Podfile.lock
@@ -14,39 +14,39 @@ PODS:
   - AFNetworking/Serialization (4.0.1)
   - AFNetworking/UIKit (4.0.1):
     - AFNetworking/NSURLSession
-  - BuzzAdBenefit (3.7.5):
-    - BuzzAdBenefitBase (~> 3.7.5)
-    - BuzzAdBenefitFeed (~> 3.7.5)
-    - BuzzAdBenefitInterstitial (~> 3.7.5)
-    - BuzzAdBenefitNative (~> 3.7.5)
-  - BuzzAdBenefitBase (3.7.5):
+  - BuzzAdBenefit (3.7.6):
+    - BuzzAdBenefitBase (~> 3.7.6)
+    - BuzzAdBenefitFeed (~> 3.7.6)
+    - BuzzAdBenefitInterstitial (~> 3.7.6)
+    - BuzzAdBenefitNative (~> 3.7.6)
+  - BuzzAdBenefitBase (3.7.6):
     - AFNetworking (~> 4.0)
     - BuzzBaseReward (~> 0.11.0)
     - BuzzBaseRewardSwift (~> 0.11.0)
     - BuzzConfig (~> 0.11.0)
     - BuzzInsight (~> 0.11.0)
     - BuzzLogger (~> 0.11.0)
-    - BuzzResource (~> 0.11.2)
+    - BuzzResource (~> 0.11.3)
     - BuzzServiceApi (~> 0.11.0)
     - BuzzUnit (~> 0.11.0)
     - ReactiveObjC (~> 3.1.1)
-  - BuzzAdBenefitFeed (3.7.5):
-    - BuzzAdBenefitBase (~> 3.7.5)
-    - BuzzAdBenefitNative (~> 3.7.5)
+  - BuzzAdBenefitFeed (3.7.6):
+    - BuzzAdBenefitBase (~> 3.7.6)
+    - BuzzAdBenefitNative (~> 3.7.6)
     - BuzzImage (~> 0.11.0)
-    - BuzzResource (~> 0.11.2)
+    - BuzzResource (~> 0.11.3)
     - BuzzServiceApi (~> 0.11.0)
     - ReactiveObjC (~> 3.1.1)
-  - BuzzAdBenefitInterstitial (3.7.5):
-    - BuzzAdBenefitBase (~> 3.7.5)
-    - BuzzAdBenefitNative (~> 3.7.5)
+  - BuzzAdBenefitInterstitial (3.7.6):
+    - BuzzAdBenefitBase (~> 3.7.6)
+    - BuzzAdBenefitNative (~> 3.7.6)
     - BuzzImage (~> 0.11.0)
-    - BuzzResource (~> 0.11.2)
+    - BuzzResource (~> 0.11.3)
     - ReactiveObjC (~> 3.1.1)
-  - BuzzAdBenefitNative (3.7.5):
-    - BuzzAdBenefitBase (~> 3.7.5)
+  - BuzzAdBenefitNative (3.7.6):
+    - BuzzAdBenefitBase (~> 3.7.6)
     - BuzzImage (~> 0.11.0)
-    - BuzzResource (~> 0.11.2)
+    - BuzzResource (~> 0.11.3)
     - GoogleAds-IMA-iOS-SDK (~> 3.12)
     - ReactiveObjC (~> 3.1.1)
   - BuzzBaseReward (0.11.0):
@@ -64,7 +64,7 @@ PODS:
     - BuzzLogger (~> 0.11.0)
     - ReactiveObjC (~> 3.1.1)
   - BuzzLogger (0.11.0)
-  - BuzzResource (0.11.2)
+  - BuzzResource (0.11.3)
   - BuzzRxSwift (6.5.0)
   - BuzzServiceApi (0.11.0):
     - ReactiveObjC (~> 3.1.1)
@@ -91,11 +91,12 @@ PODS:
   - Toast (4.0.0)
 
 DEPENDENCIES:
-  - BuzzAdBenefit (~> 3.7.5)
+  - BuzzAdBenefit (~> 3.7.6)
   - Toast (~> 4.0.0)
 
 SPEC REPOS:
-  https://github.com/Buzzvil/Specs:
+  https://github.com/CocoaPods/Specs.git:
+    - AFNetworking
     - BuzzAdBenefit
     - BuzzAdBenefitBase
     - BuzzAdBenefitFeed
@@ -108,11 +109,9 @@ SPEC REPOS:
     - BuzzInsight
     - BuzzLogger
     - BuzzResource
+    - BuzzRxSwift
     - BuzzServiceApi
     - BuzzUnit
-  https://github.com/CocoaPods/Specs.git:
-    - AFNetworking
-    - BuzzRxSwift
     - GoogleAds-IMA-iOS-SDK
     - libwebp
     - ReactiveObjC
@@ -122,18 +121,18 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   AFNetworking: 7864c38297c79aaca1500c33288e429c3451fdce
-  BuzzAdBenefit: cc703bdd77717ccadf26f10755dad6b3b9bbf71a
-  BuzzAdBenefitBase: 0e509daae2a39ed0219e1f95e070e78d91215b17
-  BuzzAdBenefitFeed: 303b3fdfdafa2b2bb62963b5bd763351d61e9597
-  BuzzAdBenefitInterstitial: 1df233c4fc0d648ca4f22ea3c4f23fcc0ced23fd
-  BuzzAdBenefitNative: 48dcc77a2da3d5b87b169c7af6b3e02bf6e1b062
+  BuzzAdBenefit: daf519ee65777fa6334e6eb33093bf206f3a22a2
+  BuzzAdBenefitBase: 1073c9c1fe7e55a838fad233de06a6604746b876
+  BuzzAdBenefitFeed: 9dbf5b0ccb53e0a06305df480a27f2836e6e4369
+  BuzzAdBenefitInterstitial: 0b44b6be2c58d2e36af56bc080f4fb213c39f405
+  BuzzAdBenefitNative: ab52c360ac5fe3d4f91dfeb868d05caafa3b49f8
   BuzzBaseReward: bfb8b88bc79948cc2495dd2b6f7fb5ae1df5a835
   BuzzBaseRewardSwift: d9d0aaf5699f710a569193ce080424641a9ee4ac
   BuzzConfig: 351d3b872681dc5659836ac3adb3a8101c9352a8
   BuzzImage: 8da95e308d7a44f6c8b282b9678b0b1cd1fb304d
   BuzzInsight: 942caab9499984aa7432707ffee4537a359146b3
   BuzzLogger: be85539d615ad88389cafef66e1378b0471d1722
-  BuzzResource: 989b26ab9be795255752c4ff61e870e98d7e2d5c
+  BuzzResource: 5d3eb853b7e4dab6e4dbaa2c621dd2b1865157bb
   BuzzRxSwift: 01dc0bdf32a917d373076926b01125f3d801695d
   BuzzServiceApi: d6d46a084b68335492c25dc5db9b04ecb33c816a
   BuzzUnit: b9fa06ba1fdafc344fefaee0d0c0248584e9ab39
@@ -144,6 +143,6 @@ SPEC CHECKSUMS:
   SDWebImageWebPCoder: 3dc350894112feab5375cfba9ce0986544a66a69
   Toast: 91b396c56ee72a5790816f40d3a94dd357abc196
 
-PODFILE CHECKSUM: 952a55d2fb1c616eb79f6a0b643af2e39ecce7bb
+PODFILE CHECKSUM: e802d32b1a05570cc64c0dfda4460603cbd1e478
 
 COCOAPODS: 1.11.2

--- a/buzzad-benefit-ios/Podfile.lock
+++ b/buzzad-benefit-ios/Podfile.lock
@@ -14,62 +14,62 @@ PODS:
   - AFNetworking/Serialization (4.0.1)
   - AFNetworking/UIKit (4.0.1):
     - AFNetworking/NSURLSession
-  - BuzzAdBenefit (3.5.1):
-    - BuzzAdBenefitBase (~> 3.5.1)
-    - BuzzAdBenefitFeed (~> 3.5.1)
-    - BuzzAdBenefitInterstitial (~> 3.5.1)
-    - BuzzAdBenefitNative (~> 3.5.1)
-  - BuzzAdBenefitBase (3.5.1):
+  - BuzzAdBenefit (3.7.5):
+    - BuzzAdBenefitBase (~> 3.7.5)
+    - BuzzAdBenefitFeed (~> 3.7.5)
+    - BuzzAdBenefitInterstitial (~> 3.7.5)
+    - BuzzAdBenefitNative (~> 3.7.5)
+  - BuzzAdBenefitBase (3.7.5):
     - AFNetworking (~> 4.0)
-    - BuzzBaseReward (~> 0.9.0)
-    - BuzzBaseRewardSwift (~> 0.9.0)
-    - BuzzConfig (~> 0.9.0)
-    - BuzzInsight (~> 0.9.0)
-    - BuzzLogger (~> 0.9.0)
-    - BuzzResource (~> 0.9.0)
-    - BuzzServiceApi (~> 0.9.0)
-    - BuzzUnit (~> 0.9.0)
+    - BuzzBaseReward (~> 0.11.0)
+    - BuzzBaseRewardSwift (~> 0.11.0)
+    - BuzzConfig (~> 0.11.0)
+    - BuzzInsight (~> 0.11.0)
+    - BuzzLogger (~> 0.11.0)
+    - BuzzResource (~> 0.11.2)
+    - BuzzServiceApi (~> 0.11.0)
+    - BuzzUnit (~> 0.11.0)
     - ReactiveObjC (~> 3.1.1)
-  - BuzzAdBenefitFeed (3.5.1):
-    - BuzzAdBenefitBase (~> 3.5.1)
-    - BuzzAdBenefitNative (~> 3.5.1)
-    - BuzzImage (~> 0.9.0)
-    - BuzzResource (~> 0.9.0)
-    - BuzzServiceApi (~> 0.9.0)
+  - BuzzAdBenefitFeed (3.7.5):
+    - BuzzAdBenefitBase (~> 3.7.5)
+    - BuzzAdBenefitNative (~> 3.7.5)
+    - BuzzImage (~> 0.11.0)
+    - BuzzResource (~> 0.11.2)
+    - BuzzServiceApi (~> 0.11.0)
     - ReactiveObjC (~> 3.1.1)
-  - BuzzAdBenefitInterstitial (3.5.1):
-    - BuzzAdBenefitBase (~> 3.5.1)
-    - BuzzAdBenefitNative (~> 3.5.1)
-    - BuzzImage (~> 0.9.0)
-    - BuzzResource (~> 0.9.0)
+  - BuzzAdBenefitInterstitial (3.7.5):
+    - BuzzAdBenefitBase (~> 3.7.5)
+    - BuzzAdBenefitNative (~> 3.7.5)
+    - BuzzImage (~> 0.11.0)
+    - BuzzResource (~> 0.11.2)
     - ReactiveObjC (~> 3.1.1)
-  - BuzzAdBenefitNative (3.5.1):
-    - BuzzAdBenefitBase (~> 3.5.1)
-    - BuzzImage (~> 0.9.0)
-    - BuzzResource (~> 0.9.0)
+  - BuzzAdBenefitNative (3.7.5):
+    - BuzzAdBenefitBase (~> 3.7.5)
+    - BuzzImage (~> 0.11.0)
+    - BuzzResource (~> 0.11.2)
     - GoogleAds-IMA-iOS-SDK (~> 3.12)
     - ReactiveObjC (~> 3.1.1)
-  - BuzzBaseReward (0.9.0):
-    - BuzzServiceApi (~> 0.9.0)
+  - BuzzBaseReward (0.11.0):
+    - BuzzServiceApi (~> 0.11.0)
     - ReactiveObjC (~> 3.1.1)
-  - BuzzBaseRewardSwift (0.9.0):
+  - BuzzBaseRewardSwift (0.11.0):
     - BuzzRxSwift (~> 6.5.0)
-  - BuzzConfig (0.9.0):
-    - BuzzServiceApi (~> 0.9.0)
+  - BuzzConfig (0.11.0):
+    - BuzzServiceApi (~> 0.11.0)
     - ReactiveObjC (~> 3.1.1)
-  - BuzzImage (0.9.0):
+  - BuzzImage (0.11.0):
     - SDWebImage (~> 5.0)
     - SDWebImageWebPCoder
-  - BuzzInsight (0.9.0):
-    - BuzzLogger (~> 0.9.0)
+  - BuzzInsight (0.11.0):
+    - BuzzLogger (~> 0.11.0)
     - ReactiveObjC (~> 3.1.1)
-  - BuzzLogger (0.9.0)
-  - BuzzResource (0.9.0)
+  - BuzzLogger (0.11.0)
+  - BuzzResource (0.11.2)
   - BuzzRxSwift (6.5.0)
-  - BuzzServiceApi (0.9.0):
+  - BuzzServiceApi (0.11.0):
     - ReactiveObjC (~> 3.1.1)
-  - BuzzUnit (0.9.0):
-    - BuzzServiceApi (~> 0.9.0)
+  - BuzzUnit (0.11.0):
+    - BuzzServiceApi (~> 0.11.0)
     - ReactiveObjC (~> 3.1.1)
   - GoogleAds-IMA-iOS-SDK (3.14.3)
   - libwebp (1.2.1):
@@ -82,21 +82,20 @@ PODS:
     - libwebp/demux
   - libwebp/webp (1.2.1)
   - ReactiveObjC (3.1.1)
-  - SDWebImage (5.12.6):
-    - SDWebImage/Core (= 5.12.6)
-  - SDWebImage/Core (5.12.6)
-  - SDWebImageWebPCoder (0.8.4):
+  - SDWebImage (5.13.0):
+    - SDWebImage/Core (= 5.13.0)
+  - SDWebImage/Core (5.13.0)
+  - SDWebImageWebPCoder (0.9.0):
     - libwebp (~> 1.0)
-    - SDWebImage/Core (~> 5.10)
+    - SDWebImage/Core (~> 5.13)
   - Toast (4.0.0)
 
 DEPENDENCIES:
-  - BuzzAdBenefit (~> 3.5.1)
+  - BuzzAdBenefit (~> 3.7.5)
   - Toast (~> 4.0.0)
 
 SPEC REPOS:
-  https://github.com/CocoaPods/Specs.git:
-    - AFNetworking
+  https://github.com/Buzzvil/Specs:
     - BuzzAdBenefit
     - BuzzAdBenefitBase
     - BuzzAdBenefitFeed
@@ -109,9 +108,11 @@ SPEC REPOS:
     - BuzzInsight
     - BuzzLogger
     - BuzzResource
-    - BuzzRxSwift
     - BuzzServiceApi
     - BuzzUnit
+  https://github.com/CocoaPods/Specs.git:
+    - AFNetworking
+    - BuzzRxSwift
     - GoogleAds-IMA-iOS-SDK
     - libwebp
     - ReactiveObjC
@@ -121,28 +122,28 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   AFNetworking: 7864c38297c79aaca1500c33288e429c3451fdce
-  BuzzAdBenefit: e175ffe1a59fc3ebf87e5d2c49bee389db659283
-  BuzzAdBenefitBase: aaabbe3750dcc3f37d333846b4a7e8e98962d1d8
-  BuzzAdBenefitFeed: bfc73b6e0e38e86a70424755ef6147dce229301d
-  BuzzAdBenefitInterstitial: de7e74d817ea998831b4f4dd3463dc144ee82dfb
-  BuzzAdBenefitNative: 646b623f4ba147d0ff9b5894a1af81dea73e9b10
-  BuzzBaseReward: 3f1667a1c2b746ead985951fbb9d565b5118af63
-  BuzzBaseRewardSwift: dde2890ae56e06e6c8d5cba5c0dfdb35727de9e7
-  BuzzConfig: d530f05353786f455394e970f4d27ea1e752beea
-  BuzzImage: e17472d3ed60aab73917e9aa652fab3b78aef6c5
-  BuzzInsight: 3cded3354d80a83e304a6f685a9e7a1f2457806c
-  BuzzLogger: 101d7e4afc1deb534c956ff2091a4daf800028de
-  BuzzResource: 31723023bf588d9cf9cf546986ebcd67297cb49e
+  BuzzAdBenefit: cc703bdd77717ccadf26f10755dad6b3b9bbf71a
+  BuzzAdBenefitBase: 0e509daae2a39ed0219e1f95e070e78d91215b17
+  BuzzAdBenefitFeed: 303b3fdfdafa2b2bb62963b5bd763351d61e9597
+  BuzzAdBenefitInterstitial: 1df233c4fc0d648ca4f22ea3c4f23fcc0ced23fd
+  BuzzAdBenefitNative: 48dcc77a2da3d5b87b169c7af6b3e02bf6e1b062
+  BuzzBaseReward: bfb8b88bc79948cc2495dd2b6f7fb5ae1df5a835
+  BuzzBaseRewardSwift: d9d0aaf5699f710a569193ce080424641a9ee4ac
+  BuzzConfig: 351d3b872681dc5659836ac3adb3a8101c9352a8
+  BuzzImage: 8da95e308d7a44f6c8b282b9678b0b1cd1fb304d
+  BuzzInsight: 942caab9499984aa7432707ffee4537a359146b3
+  BuzzLogger: be85539d615ad88389cafef66e1378b0471d1722
+  BuzzResource: 989b26ab9be795255752c4ff61e870e98d7e2d5c
   BuzzRxSwift: 01dc0bdf32a917d373076926b01125f3d801695d
-  BuzzServiceApi: 49f3c57b84c3e6c13beb7f09c708acb71512764a
-  BuzzUnit: da51624b0aeee1a234c0794fce09f6582053deee
+  BuzzServiceApi: d6d46a084b68335492c25dc5db9b04ecb33c816a
+  BuzzUnit: b9fa06ba1fdafc344fefaee0d0c0248584e9ab39
   GoogleAds-IMA-iOS-SDK: 2a9b7b14bda4993306f05287f952dce41b5be4ad
   libwebp: 98a37e597e40bfdb4c911fc98f2c53d0b12d05fc
   ReactiveObjC: 011caa393aa0383245f2dcf9bf02e86b80b36040
-  SDWebImage: a47aea9e3d8816015db4e523daff50cfd294499d
-  SDWebImageWebPCoder: f93010f3f6c031e2f8fb3081ca4ee6966c539815
+  SDWebImage: 0327043dbb9533e75f2eff8445b3df0f2ceca6ac
+  SDWebImageWebPCoder: 3dc350894112feab5375cfba9ce0986544a66a69
   Toast: 91b396c56ee72a5790816f40d3a94dd357abc196
 
-PODFILE CHECKSUM: 5a0e163957740bb670b419f181d13c0eb6c7a3c5
+PODFILE CHECKSUM: 952a55d2fb1c616eb79f6a0b643af2e39ecce7bb
 
 COCOAPODS: 1.11.2

--- a/buzzad-benefit-ios/README.md
+++ b/buzzad-benefit-ios/README.md
@@ -6,6 +6,9 @@
 ### 오픈 소스 라이센스 고지
 - 이 소프트웨어가 사용하는 오픈 소스 소프트웨어의 라이센스는 "오픈 소스 라이센스 고지 페이지 ([원본 파일](docs/3rd_party_licenses.html)|[렌더링 버전](https://htmlpreview.github.io/?https://github.com/Buzzvil/buzzscreen-sdk-publisher/blob/master/docs/3rd_party_licenses.html))"에서 확인할 수 있다.
 
+## [3.7.6] - 2022-07-14
+* [NEW] 개인정보를 제공하지 않는 사용자가 피드 지면에 진입하면 개인정보 수집 동의 팝업을 띄우는 기능을 추가
+
 ## [3.5.1] - 2022-06-16
 * [FIX] 피드 지면의 광고 미할당 안내 이미지 개선
 * [FIX] 광고의 impression 발생 여부 확인 로직 개선


### PR DESCRIPTION
퍼블릭 샘플 애플리케이션의 BuzzAd iOS SDK 버전을 3.7.6 으로 업데이트 했습니다.