### PR TITLE
BuzzAd iOS SDK 3.11.3

### DIFF
--- a/buzzad-benefit-ios/Podfile
+++ b/buzzad-benefit-ios/Podfile
@@ -6,7 +6,7 @@ use_frameworks!
 inhibit_all_warnings!
 
 target 'BABSample' do
-  pod 'BuzzAdBenefit', '~> 3.11.3'
+  pod 'BuzzAdBenefit', '~> 3.13.1'
   pod 'Toast', '~> 4.0.0'
 end
 

--- a/buzzad-benefit-ios/Podfile.lock
+++ b/buzzad-benefit-ios/Podfile.lock
@@ -14,52 +14,52 @@ PODS:
   - AFNetworking/Serialization (4.0.1)
   - AFNetworking/UIKit (4.0.1):
     - AFNetworking/NSURLSession
-  - BuzzAdBenefit (3.11.3):
-    - BuzzAdBenefitBase (~> 3.11.3)
-    - BuzzAdBenefitFeed (~> 3.11.3)
-    - BuzzAdBenefitInterstitial (~> 3.11.3)
-    - BuzzAdBenefitNative (~> 3.11.3)
-  - BuzzAdBenefitBase (3.11.3):
+  - BuzzAdBenefit (3.13.1):
+    - BuzzAdBenefitBase (~> 3.13.1)
+    - BuzzAdBenefitFeed (~> 3.13.1)
+    - BuzzAdBenefitInterstitial (~> 3.13.1)
+    - BuzzAdBenefitNative (~> 3.13.1)
+  - BuzzAdBenefitBase (3.13.1):
     - AFNetworking (~> 4.0)
-    - BuzzBaseRewardSwift (~> 0.15.0)
-    - BuzzInsight (~> 0.15.0)
-    - BuzzLogger (~> 0.15.0)
-    - BuzzResource (~> 0.15.1)
-    - BuzzServiceApi (~> 0.15.0)
-    - BuzzUnit (~> 0.15.0)
+    - BuzzBaseRewardSwift (~> 0.17.0)
+    - BuzzInsight (~> 0.17.0)
+    - BuzzLogger (~> 0.17.0)
+    - BuzzResource (~> 0.17.0)
+    - BuzzServiceApi (~> 0.17.0)
+    - BuzzUnit (~> 0.17.0)
     - ReactiveObjC (~> 3.1.1)
-  - BuzzAdBenefitFeed (3.11.3):
-    - BuzzAdBenefitBase (~> 3.11.3)
-    - BuzzAdBenefitNative (~> 3.11.3)
-    - BuzzImage (~> 0.15.0)
-    - BuzzResource (~> 0.15.1)
-    - BuzzServiceApi (~> 0.15.0)
+  - BuzzAdBenefitFeed (3.13.1):
+    - BuzzAdBenefitBase (~> 3.13.1)
+    - BuzzAdBenefitNative (~> 3.13.1)
+    - BuzzImage (~> 0.17.0)
+    - BuzzResource (~> 0.17.0)
+    - BuzzServiceApi (~> 0.17.0)
     - ReactiveObjC (~> 3.1.1)
-  - BuzzAdBenefitInterstitial (3.11.3):
-    - BuzzAdBenefitBase (~> 3.11.3)
-    - BuzzAdBenefitNative (~> 3.11.3)
+  - BuzzAdBenefitInterstitial (3.13.1):
+    - BuzzAdBenefitBase (~> 3.13.1)
+    - BuzzAdBenefitNative (~> 3.13.1)
     - ReactiveObjC (~> 3.1.1)
-  - BuzzAdBenefitNative (3.11.3):
-    - BuzzAdBenefitBase (~> 3.11.3)
-    - BuzzImage (~> 0.15.0)
-    - BuzzResource (~> 0.15.1)
+  - BuzzAdBenefitNative (3.13.1):
+    - BuzzAdBenefitBase (~> 3.13.1)
+    - BuzzImage (~> 0.17.0)
+    - BuzzResource (~> 0.17.0)
     - GoogleAds-IMA-iOS-SDK (~> 3.12)
     - ReactiveObjC (~> 3.1.1)
-  - BuzzBaseRewardSwift (0.15.0):
+  - BuzzBaseRewardSwift (0.17.0):
     - BuzzRxSwift (~> 6.5.0)
-  - BuzzImage (0.15.0):
+  - BuzzImage (0.17.0):
     - SDWebImage (~> 5.0)
     - SDWebImageWebPCoder
-  - BuzzInsight (0.15.0):
-    - BuzzLogger (~> 0.15.0)
+  - BuzzInsight (0.17.0):
+    - BuzzLogger (~> 0.17.0)
     - ReactiveObjC (~> 3.1.1)
-  - BuzzLogger (0.15.0)
-  - BuzzResource (0.15.1)
+  - BuzzLogger (0.17.0)
+  - BuzzResource (0.17.0)
   - BuzzRxSwift (6.5.0)
-  - BuzzServiceApi (0.15.0):
+  - BuzzServiceApi (0.17.0):
     - ReactiveObjC (~> 3.1.1)
-  - BuzzUnit (0.15.0):
-    - BuzzServiceApi (~> 0.15.0)
+  - BuzzUnit (0.17.0):
+    - BuzzServiceApi (~> 0.17.0)
     - ReactiveObjC (~> 3.1.1)
   - GoogleAds-IMA-iOS-SDK (3.14.3)
   - libwebp (1.2.3):
@@ -72,16 +72,16 @@ PODS:
     - libwebp/demux
   - libwebp/webp (1.2.3)
   - ReactiveObjC (3.1.1)
-  - SDWebImage (5.13.2):
-    - SDWebImage/Core (= 5.13.2)
-  - SDWebImage/Core (5.13.2)
-  - SDWebImageWebPCoder (0.9.0):
+  - SDWebImage (5.13.4):
+    - SDWebImage/Core (= 5.13.4)
+  - SDWebImage/Core (5.13.4)
+  - SDWebImageWebPCoder (0.9.1):
     - libwebp (~> 1.0)
     - SDWebImage/Core (~> 5.13)
   - Toast (4.0.0)
 
 DEPENDENCIES:
-  - BuzzAdBenefit (~> 3.11.3)
+  - BuzzAdBenefit (~> 3.13.1)
   - Toast (~> 4.0.0)
 
 SPEC REPOS:
@@ -109,26 +109,26 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   AFNetworking: 7864c38297c79aaca1500c33288e429c3451fdce
-  BuzzAdBenefit: 372ca458d4be0ff3518b2e63640f38d3cd54fd55
-  BuzzAdBenefitBase: 675a37c8e26923d2988c577cfc9ba991ec2935ae
-  BuzzAdBenefitFeed: 3b85ea0c4407e9c98f34702ed2a6854fa5ac64b2
-  BuzzAdBenefitInterstitial: 079e434ad9f92d57a2bbf30f7461a043ab034c05
-  BuzzAdBenefitNative: d4cd2c6a47c18fceef8bc75aedab07e2d7ba19fe
-  BuzzBaseRewardSwift: 4aa5530dbae1713bbcbce6fe18888bdfa39128e0
-  BuzzImage: 675c21ec92bf1fe625151b580aa8236b79297bfc
-  BuzzInsight: 63ad85ade55a62fa9381e1c68e4f86e2149a0c87
-  BuzzLogger: 39c16229fb979660f38fc12b5ba020c073943b03
-  BuzzResource: 6d011b891acf1f1ceb21b1cdc17baab4cf6db586
+  BuzzAdBenefit: b648b35fd1cf7eafec4f02ce2c2fa36df78ac675
+  BuzzAdBenefitBase: 6e3fc99d172fc1ec9f68e49264640b35a659ec0d
+  BuzzAdBenefitFeed: dfb44eb67d138eb371f9498ea7848bc67b6b6044
+  BuzzAdBenefitInterstitial: ca1f0c8e3e9c86b146407fe5a417601867b30a63
+  BuzzAdBenefitNative: d633f71da7731fe3940a44c5cfaafa02e5b72397
+  BuzzBaseRewardSwift: 9e83f7745a1729f5eb2b07e088bb0f16af470660
+  BuzzImage: af2038dfbbbe80cd3416da8b18d94b17973c8486
+  BuzzInsight: c4bea7136f61744a9d838b2d52c520dda96de03b
+  BuzzLogger: a3c6ed879744de9e23632058a4c14dbddba2a0d0
+  BuzzResource: 457ab83a541a860a536894a6e656c81b13db4a10
   BuzzRxSwift: 01dc0bdf32a917d373076926b01125f3d801695d
-  BuzzServiceApi: 088d66b56d114828b8dcd1491bccc0d58cd4214a
-  BuzzUnit: dc0a6e86433d6a75689ccd2127935b099ae9d5dd
+  BuzzServiceApi: 10a96c3e744d7076624929a739b9257aed30fc5b
+  BuzzUnit: 118e45c9deb9254ec21cac02b6ab6b4be27b0682
   GoogleAds-IMA-iOS-SDK: 2a9b7b14bda4993306f05287f952dce41b5be4ad
   libwebp: 60305b2e989864154bd9be3d772730f08fc6a59c
   ReactiveObjC: 011caa393aa0383245f2dcf9bf02e86b80b36040
-  SDWebImage: 72f86271a6f3139cc7e4a89220946489d4b9a866
-  SDWebImageWebPCoder: 3dc350894112feab5375cfba9ce0986544a66a69
+  SDWebImage: e5cc87bf736e60f49592f307bdf9e157189298a3
+  SDWebImageWebPCoder: 18503de6621dd2c420d680e33d46bf8e1d5169b0
   Toast: 91b396c56ee72a5790816f40d3a94dd357abc196
 
-PODFILE CHECKSUM: a812e998881d7b7cb713458fc526cb840e3ab338
+PODFILE CHECKSUM: 56e9e7f7cd95d5caf85a836c478e0496976531ba
 
 COCOAPODS: 1.11.3

--- a/buzzad-benefit-ios/README.md
+++ b/buzzad-benefit-ios/README.md
@@ -6,6 +6,13 @@
 ### 오픈 소스 라이센스 고지
 - 이 소프트웨어가 사용하는 오픈 소스 소프트웨어의 라이센스는 "오픈 소스 라이센스 고지 페이지 ([원본 파일](docs/3rd_party_licenses.html)|[렌더링 버전](https://htmlpreview.github.io/?https://github.com/Buzzvil/buzzscreen-sdk-publisher/blob/master/docs/3rd_party_licenses.html))"에서 확인할 수 있다.
 
+## [3.13.1] - 2022-10-06
+* [NEW] iOS 16을 위한 대응
+* [NEW] revenueType에 새로운 액션형 광고 유형 추가
+* [NEW] 다양한 기획을 지원하기 위한 광고 유형 확인 함수 추가
+* [FIX] 피드 지면에서 진입한 광고 페이지 웹뷰와 브라우저 상단의 내비게이션이 겹쳐서 보여지는 문제 해결
+* [FIX] 유저가 개인정보 수집에 동의한 다음 앱을 삭제 후 재설치 시 간헐적으로 발생하는 크래시 오류 해결
+
 ## [3.11.3] - 2022-09-08
 * [UPDATE] Feed 지면에서 광고가 할당되지 않을 때 표시되는 UI 개선
 * [UPDATE] Feed 광고 분류 탭의 인디케이터 색상의 커스터마이징 기능 추가


### PR DESCRIPTION
퍼블릭 샘플 애플리케이션의 BuzzAd iOS SDK 버전을 3.13.1 으로 업데이트 했습니다.