### PR TITLE
BuzzAd iOS SDK 3.21.2

### DIFF
--- a/buzzad-benefit-ios/BABSample/AppDelegate.m
+++ b/buzzad-benefit-ios/BABSample/AppDelegate.m
@@ -52,6 +52,9 @@
   [BuzzAdBenefit initializeWithConfig:config];
 
   BZVBuzzAdFeedTheme *buzzAdFeedTheme = [BZVBuzzAdFeedTheme themeWithBlock:^(BZVBuzzAdFeedThemeBuilder * _Nonnull builder) {
+    // MARK: 피드 디자인 커스터마이징 - 피드 디자인 변경하기
+//    builder.feedBackgroundColor = UIColor.whiteColor;
+    
     // MARK: 피드 디자인 커스터마이징 - 탭 디자인 변경하기
 //    builder.tabBackgroundColor = UIColor.orangeColor;
 //    builder.tabTextColor = [BZVControlStateResource resourceWithBlock:^(BZVControlStateResourceBuilder * _Nonnull builder) {

--- a/buzzad-benefit-ios/BABSample/AppDelegate.m
+++ b/buzzad-benefit-ios/BABSample/AppDelegate.m
@@ -53,7 +53,7 @@
 
   BZVBuzzAdFeedTheme *buzzAdFeedTheme = [BZVBuzzAdFeedTheme themeWithBlock:^(BZVBuzzAdFeedThemeBuilder * _Nonnull builder) {
     // MARK: 피드 디자인 커스터마이징 - 피드 디자인 변경하기
-//    builder.feedBackgroundColor = UIColor.whiteColor;
+//    builder.feedBackgroundColor = UIColor.greenColor;
     
     // MARK: 피드 디자인 커스터마이징 - 탭 디자인 변경하기
 //    builder.tabBackgroundColor = UIColor.orangeColor;

--- a/buzzad-benefit-ios/BABSample/AppDelegate.m
+++ b/buzzad-benefit-ios/BABSample/AppDelegate.m
@@ -51,6 +51,9 @@
   }];
   [BuzzAdBenefit initializeWithConfig:config];
 
+  // MARK: 시작하기 - 다크 모드 설정하기
+//  [BuzzAdBenefit setUserInterfaceStyle:BZVUserInterfaceStyleSystem];
+  
   BZVBuzzAdFeedTheme *buzzAdFeedTheme = [BZVBuzzAdFeedTheme themeWithBlock:^(BZVBuzzAdFeedThemeBuilder * _Nonnull builder) {
     // MARK: 피드 디자인 커스터마이징 - 피드 디자인 변경하기
 //    builder.feedBackgroundColor = UIColor.greenColor;

--- a/buzzad-benefit-ios/Podfile
+++ b/buzzad-benefit-ios/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '10.0'
+platform :ios, '11.0'
 
 source 'https://github.com/CocoaPods/Specs.git'
 
@@ -6,6 +6,6 @@ use_frameworks!
 inhibit_all_warnings!
 
 target 'BABSample' do
-  pod 'BuzzAdBenefit', '~> 3.19.0'
+  pod 'BuzzAdBenefit', '~> 3.21.2'
   pod 'Toast', '~> 4.0.0'
 end

--- a/buzzad-benefit-ios/Podfile.lock
+++ b/buzzad-benefit-ios/Podfile.lock
@@ -14,64 +14,57 @@ PODS:
   - AFNetworking/Serialization (4.0.1)
   - AFNetworking/UIKit (4.0.1):
     - AFNetworking/NSURLSession
-  - BuzzAdBenefit (3.19.0):
-    - BuzzAdBenefitBase (~> 3.19.0)
-    - BuzzAdBenefitFeed (~> 3.19.0)
-    - BuzzAdBenefitInterstitial (~> 3.19.0)
-    - BuzzAdBenefitNative (~> 3.19.0)
-    - BuzzCore (~> 0.23.0)
-  - BuzzAdBenefitBase (3.19.0):
+  - BuzzAdBenefit (3.21.2):
+    - BuzzAdBenefitBase (~> 3.21.2)
+    - BuzzAdBenefitFeed (~> 3.21.2)
+    - BuzzAdBenefitInterstitial (~> 3.21.2)
+    - BuzzAdBenefitNative (~> 3.21.2)
+    - BuzzCore (~> 0.25.1)
+  - BuzzAdBenefitBase (3.21.2):
     - AFNetworking (~> 4.0)
-    - BuzzBaseRewardSwift (~> 0.23.0)
-    - BuzzCore (~> 0.23.0)
-    - BuzzInsight (~> 0.23.0)
-    - BuzzLogger (~> 0.23.0)
-    - BuzzResource (~> 0.23.0)
-    - BuzzRxSwift (~> 6.5.0)
-    - BuzzServiceApi (~> 0.23.0)
-    - BuzzUnit (~> 0.23.0)
+    - BuzzBaseRewardSwift (~> 0.25.1)
+    - BuzzCore (~> 0.25.1)
+    - BuzzInsight (~> 0.25.1)
+    - BuzzResource (~> 0.25.1)
+    - BuzzRxSwift (~> 6.5.1)
+    - BuzzServiceApi (~> 0.25.1)
+    - BuzzUnit (~> 0.25.1)
     - ReactiveObjC (~> 3.1.1)
-  - BuzzAdBenefitFeed (3.19.0):
-    - BuzzAdBenefitBase (~> 3.19.0)
-    - BuzzAdBenefitNative (~> 3.19.0)
-    - BuzzCore (~> 0.23.0)
-    - BuzzImage (~> 0.23.0)
-    - BuzzResource (~> 0.23.0)
-    - BuzzRxSwift (~> 6.5.0)
-    - BuzzServiceApi (~> 0.23.0)
+  - BuzzAdBenefitFeed (3.21.2):
+    - BuzzAdBenefitBase (~> 3.21.2)
+    - BuzzAdBenefitNative (~> 3.21.2)
+    - BuzzCore (~> 0.25.1)
+    - BuzzResource (~> 0.25.1)
+    - BuzzRxSwift (~> 6.5.1)
+    - BuzzServiceApi (~> 0.25.1)
     - ReactiveObjC (~> 3.1.1)
-  - BuzzAdBenefitInterstitial (3.19.0):
-    - BuzzAdBenefitBase (~> 3.19.0)
-    - BuzzAdBenefitNative (~> 3.19.0)
+  - BuzzAdBenefitInterstitial (3.21.2):
+    - BuzzAdBenefitBase (~> 3.21.2)
+    - BuzzAdBenefitNative (~> 3.21.2)
     - ReactiveObjC (~> 3.1.1)
-  - BuzzAdBenefitNative (3.19.0):
-    - BuzzAdBenefitBase (~> 3.19.0)
-    - BuzzImage (~> 0.23.0)
-    - BuzzResource (~> 0.23.0)
-    - BuzzRxSwift (~> 6.5.0)
+  - BuzzAdBenefitNative (3.21.2):
+    - BuzzAdBenefitBase (~> 3.21.2)
+    - BuzzResource (~> 0.25.1)
+    - BuzzRxSwift (~> 6.5.1)
     - GoogleAds-IMA-iOS-SDK (~> 3.12)
     - ReactiveObjC (~> 3.1.1)
-  - BuzzBaseRewardSwift (0.23.0):
-    - BuzzRxSwift (~> 6.5.0)
-  - BuzzCore (0.23.0):
-    - BuzzRxSwift (~> 6.5.0)
+  - BuzzBaseRewardSwift (0.25.1):
+    - BuzzRxSwift (~> 6.5.1)
+  - BuzzCore (0.25.1):
+    - BuzzRxSwift (~> 6.5.1)
     - SDWebImage (~> 5.0)
     - SDWebImageWebPCoder
-  - BuzzImage (0.23.0):
-    - SDWebImage (~> 5.0)
-    - SDWebImageWebPCoder
-  - BuzzInsight (0.23.0):
-    - BuzzLogger (~> 0.23.0)
+  - BuzzInsight (0.25.1):
+    - BuzzCore (~> 0.25.1)
     - ReactiveObjC (~> 3.1.1)
-  - BuzzLogger (0.23.0)
-  - BuzzResource (0.23.0)
-  - BuzzRxSwift (6.5.0)
-  - BuzzServiceApi (0.23.0):
+  - BuzzResource (0.25.1)
+  - BuzzRxSwift (6.5.1)
+  - BuzzServiceApi (0.25.1):
     - ReactiveObjC (~> 3.1.1)
-  - BuzzUnit (0.23.0):
-    - BuzzServiceApi (~> 0.23.0)
+  - BuzzUnit (0.25.1):
+    - BuzzServiceApi (~> 0.25.1)
     - ReactiveObjC (~> 3.1.1)
-  - GoogleAds-IMA-iOS-SDK (3.14.3)
+  - GoogleAds-IMA-iOS-SDK (3.14.5)
   - libwebp (1.2.4):
     - libwebp/demux (= 1.2.4)
     - libwebp/mux (= 1.2.4)
@@ -82,16 +75,16 @@ PODS:
     - libwebp/demux
   - libwebp/webp (1.2.4)
   - ReactiveObjC (3.1.1)
-  - SDWebImage (5.14.3):
-    - SDWebImage/Core (= 5.14.3)
-  - SDWebImage/Core (5.14.3)
-  - SDWebImageWebPCoder (0.9.1):
+  - SDWebImage (5.15.0):
+    - SDWebImage/Core (= 5.15.0)
+  - SDWebImage/Core (5.15.0)
+  - SDWebImageWebPCoder (0.10.0):
     - libwebp (~> 1.0)
-    - SDWebImage/Core (~> 5.13)
+    - SDWebImage/Core (~> 5.15)
   - Toast (4.0.0)
 
 DEPENDENCIES:
-  - BuzzAdBenefit (~> 3.19.0)
+  - BuzzAdBenefit (~> 3.21.2)
   - Toast (~> 4.0.0)
 
 SPEC REPOS:
@@ -104,9 +97,7 @@ SPEC REPOS:
     - BuzzAdBenefitNative
     - BuzzBaseRewardSwift
     - BuzzCore
-    - BuzzImage
     - BuzzInsight
-    - BuzzLogger
     - BuzzResource
     - BuzzRxSwift
     - BuzzServiceApi
@@ -119,28 +110,26 @@ SPEC REPOS:
     - Toast
 
 SPEC CHECKSUMS:
-  AFNetworking: 7864c38297c79aaca1500c33288e429c3451fdce
-  BuzzAdBenefit: 1ce7160d36b8db227a552b9f7bd220179e033ff1
-  BuzzAdBenefitBase: aafb6d027253cca17a72340fbdcfaf25f508117d
-  BuzzAdBenefitFeed: e2d557b000fef1b7f86f2a687cb0531f23193354
-  BuzzAdBenefitInterstitial: 0f8e4dbdfdf56b54c192aa8ef1821732b9301452
-  BuzzAdBenefitNative: 768fedff2c24cf91b3554da3eab34564a48c4a8e
-  BuzzBaseRewardSwift: d7a278cf28f96e14adaa72dd5f6687f730cef1e5
-  BuzzCore: 257ba423bcf17146849d6985c9fb7630d5a24b66
-  BuzzImage: c962e940da4275b676bd1aaae5c7224b78f84424
-  BuzzInsight: a3e60e11dca7c4ab58ad0fb891b344ff73faddf2
-  BuzzLogger: 0add440398fb2ad7b19096d6d92f9792da8f60d4
-  BuzzResource: b99c4901e2df56f533e0ba190770aec1d54b080b
-  BuzzRxSwift: 01dc0bdf32a917d373076926b01125f3d801695d
-  BuzzServiceApi: 18cc0c23b1ac6952186caffdb079f5869592eb29
-  BuzzUnit: d42a6744bf13d9901aed8d15417b124e737945bf
-  GoogleAds-IMA-iOS-SDK: 2a9b7b14bda4993306f05287f952dce41b5be4ad
+  AFNetworking: 3bd23d814e976cd148d7d44c3ab78017b744cd58
+  BuzzAdBenefit: 53a627472436f561961746589f7db63d96922e36
+  BuzzAdBenefitBase: 0f5d8813d2a9115ccf8abab5054e470e274ee006
+  BuzzAdBenefitFeed: 24323d04ec7a93a24b26c153442026d306ae7af3
+  BuzzAdBenefitInterstitial: c93a295946055d41d36c51ad703f7acb6ae5bf69
+  BuzzAdBenefitNative: 608fb96599823e40ad5bb35d54a83be4c03d76f3
+  BuzzBaseRewardSwift: 2194f9edb0b9488b16d92184aab28e38d7e02762
+  BuzzCore: 46c01b51ce3ef3a2760e322eec983969eea2b54f
+  BuzzInsight: 57d7c65a2f3812696df482fc7c83d6305c3e2061
+  BuzzResource: a9d926cac0dd831ba8dbbaa9c3b6c717899b2f2f
+  BuzzRxSwift: 0ca1668aa41a0b4a811c9eb00d74c89a95a8553f
+  BuzzServiceApi: bab4249883ef88a715a3a32307f6a8f44f7fab3f
+  BuzzUnit: 62a97b9b44b0e8d05f4b3225c4071911534b58aa
+  GoogleAds-IMA-iOS-SDK: b088674002266c5638e73d10696c8b13872ee15e
   libwebp: f62cb61d0a484ba548448a4bd52aabf150ff6eef
   ReactiveObjC: 011caa393aa0383245f2dcf9bf02e86b80b36040
-  SDWebImage: 9c36e66c8ce4620b41a7407698dda44211a96764
-  SDWebImageWebPCoder: 18503de6621dd2c420d680e33d46bf8e1d5169b0
+  SDWebImage: 9bec4c5cdd9579e1f57104735ee0c37df274d593
+  SDWebImageWebPCoder: 07b5d53b3adcc3d491312a58ea103e36af1692c1
   Toast: 91b396c56ee72a5790816f40d3a94dd357abc196
 
-PODFILE CHECKSUM: 4f9e4c29ce93ace9b3a483e511da37b5cc6da753
+PODFILE CHECKSUM: 262ae31a6443eb4d2867d4250d2243afb6ba9296
 
 COCOAPODS: 1.11.3

--- a/buzzad-benefit-ios/README.md
+++ b/buzzad-benefit-ios/README.md
@@ -6,6 +6,14 @@
 ### 오픈 소스 라이센스 고지
 - 이 소프트웨어가 사용하는 오픈 소스 소프트웨어의 라이센스는 "오픈 소스 라이센스 고지 페이지 ([원본 파일](docs/3rd_party_licenses.html)|[렌더링 버전](https://htmlpreview.github.io/?https://github.com/Buzzvil/buzzscreen-sdk-publisher/blob/master/docs/3rd_party_licenses.html))"에서 확인할 수 있다.
 
+## [3.21.2] - 2023-01-26
+* [CHANGE] Xcode 14에서 BuzzAd iOS SDK를 사용할 때 Warning이 발생하지 않도록 Minimum deployment target을 11로 상향
+* [NEW] 커스텀 인앱 브라우저 사용 시 딥링크 광고 여부를 확인하는 인터페이스 추가
+* [NEW] 네이티브, 피드, 인터스티셜 다크 모드 지원
+* [NEW] revenueType에 새로운 액션형 광고 유형 추가​
+* [NEW] 피드 배경 색상을 커스터마이징하는 인터페이스 추가
+* [UPDATE] 광고 분류 탭과 필터 비활성화 기능 추가
+
 ## [3.19.0] - 2022-12-28
 * [NEW] 피드 상단으로 바로 이동할 수 있는 맨위로가기 버튼 추가
 * [UPDATE] 광고 프리로드 중복 요청에 대한 오류 코드 추가


### PR DESCRIPTION
### Description
퍼블릭 샘플 애플리케이션의 BuzzAd iOS SDK 버전을 3.21.2 으로 업데이트 합니다.

### Checklist
- [x] 연동가이드 추가된 부분 반영
- [x] README 업데이트
- [x] SDK 버전 업데이트
- [x] Podfile source reminder