### PR TITLE
BuzzAd iOS SDK 3.23.3

### DIFF
--- a/buzzad-benefit-ios/Podfile
+++ b/buzzad-benefit-ios/Podfile
@@ -6,6 +6,6 @@ use_frameworks!
 inhibit_all_warnings!
 
 target 'BABSample' do
-  pod 'BuzzAdBenefit', '~> 3.21.4'
+  pod 'BuzzAdBenefit', '~> 3.23.3'
   pod 'Toast', '~> 4.0.0'
 end

--- a/buzzad-benefit-ios/Podfile.lock
+++ b/buzzad-benefit-ios/Podfile.lock
@@ -14,55 +14,55 @@ PODS:
   - AFNetworking/Serialization (4.0.1)
   - AFNetworking/UIKit (4.0.1):
     - AFNetworking/NSURLSession
-  - BuzzAdBenefit (3.21.4):
-    - BuzzAdBenefitBase (~> 3.21.4)
-    - BuzzAdBenefitFeed (~> 3.21.4)
-    - BuzzAdBenefitInterstitial (~> 3.21.4)
-    - BuzzAdBenefitNative (~> 3.21.4)
-    - BuzzCore (~> 0.25.1)
-  - BuzzAdBenefitBase (3.21.4):
+  - BuzzAdBenefit (3.23.3):
+    - BuzzAdBenefitBase (~> 3.23.3)
+    - BuzzAdBenefitFeed (~> 3.23.3)
+    - BuzzAdBenefitInterstitial (~> 3.23.3)
+    - BuzzAdBenefitNative (~> 3.23.3)
+    - BuzzCore (~> 0.27.0)
+  - BuzzAdBenefitBase (3.23.3):
     - AFNetworking (~> 4.0)
-    - BuzzBaseRewardSwift (~> 0.25.1)
-    - BuzzCore (~> 0.25.1)
-    - BuzzInsight (~> 0.25.1)
-    - BuzzResource (~> 0.25.1)
+    - BuzzBaseRewardSwift (~> 0.27.0)
+    - BuzzCore (~> 0.27.0)
+    - BuzzInsight (~> 0.27.0)
+    - BuzzResource (~> 0.27.0)
     - BuzzRxSwift (~> 6.5.1)
-    - BuzzServiceApi (~> 0.25.1)
-    - BuzzUnit (~> 0.25.1)
+    - BuzzServiceApi (~> 0.27.0)
+    - BuzzUnit (~> 0.27.0)
     - ReactiveObjC (~> 3.1.1)
-  - BuzzAdBenefitFeed (3.21.4):
-    - BuzzAdBenefitBase (~> 3.21.4)
-    - BuzzAdBenefitNative (~> 3.21.4)
-    - BuzzCore (~> 0.25.1)
-    - BuzzResource (~> 0.25.1)
+  - BuzzAdBenefitFeed (3.23.3):
+    - BuzzAdBenefitBase (~> 3.23.3)
+    - BuzzAdBenefitNative (~> 3.23.3)
+    - BuzzCore (~> 0.27.0)
+    - BuzzResource (~> 0.27.0)
     - BuzzRxSwift (~> 6.5.1)
-    - BuzzServiceApi (~> 0.25.1)
+    - BuzzServiceApi (~> 0.27.0)
     - ReactiveObjC (~> 3.1.1)
-  - BuzzAdBenefitInterstitial (3.21.4):
-    - BuzzAdBenefitBase (~> 3.21.4)
-    - BuzzAdBenefitNative (~> 3.21.4)
+  - BuzzAdBenefitInterstitial (3.23.3):
+    - BuzzAdBenefitBase (~> 3.23.3)
+    - BuzzAdBenefitNative (~> 3.23.3)
     - ReactiveObjC (~> 3.1.1)
-  - BuzzAdBenefitNative (3.21.4):
-    - BuzzAdBenefitBase (~> 3.21.4)
-    - BuzzResource (~> 0.25.1)
+  - BuzzAdBenefitNative (3.23.3):
+    - BuzzAdBenefitBase (~> 3.23.3)
+    - BuzzResource (~> 0.27.0)
     - BuzzRxSwift (~> 6.5.1)
     - GoogleAds-IMA-iOS-SDK (~> 3.12)
     - ReactiveObjC (~> 3.1.1)
-  - BuzzBaseRewardSwift (0.25.1):
+  - BuzzBaseRewardSwift (0.27.0):
     - BuzzRxSwift (~> 6.5.1)
-  - BuzzCore (0.25.1):
+  - BuzzCore (0.27.0):
     - BuzzRxSwift (~> 6.5.1)
     - SDWebImage (~> 5.0)
     - SDWebImageWebPCoder
-  - BuzzInsight (0.25.1):
-    - BuzzCore (~> 0.25.1)
+  - BuzzInsight (0.27.0):
+    - BuzzCore (~> 0.27.0)
     - ReactiveObjC (~> 3.1.1)
-  - BuzzResource (0.25.1)
+  - BuzzResource (0.27.0)
   - BuzzRxSwift (6.5.1)
-  - BuzzServiceApi (0.25.1):
+  - BuzzServiceApi (0.27.0):
     - ReactiveObjC (~> 3.1.1)
-  - BuzzUnit (0.25.1):
-    - BuzzServiceApi (~> 0.25.1)
+  - BuzzUnit (0.27.0):
+    - BuzzServiceApi (~> 0.27.0)
     - ReactiveObjC (~> 3.1.1)
   - GoogleAds-IMA-iOS-SDK (3.14.5)
   - libwebp (1.2.4):
@@ -84,7 +84,7 @@ PODS:
   - Toast (4.0.0)
 
 DEPENDENCIES:
-  - BuzzAdBenefit (~> 3.21.4)
+  - BuzzAdBenefit (~> 3.23.3)
   - Toast (~> 4.0.0)
 
 SPEC REPOS:
@@ -111,18 +111,18 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   AFNetworking: 3bd23d814e976cd148d7d44c3ab78017b744cd58
-  BuzzAdBenefit: 071707b4201fa4c4ab5c39acba5931a8a854f514
-  BuzzAdBenefitBase: a5d9763559b7e66d9f4613d3297fe96ad78a5c55
-  BuzzAdBenefitFeed: 6bb93b35cfbfb6c4b3236e9033981b2a2d9a2cb9
-  BuzzAdBenefitInterstitial: 0ecdefe39d4a31d85f3f91f29c379877cfe96b39
-  BuzzAdBenefitNative: 9e7a59d588a6fd29cb3e984b496eed650f8c3bff
-  BuzzBaseRewardSwift: 2194f9edb0b9488b16d92184aab28e38d7e02762
-  BuzzCore: 46c01b51ce3ef3a2760e322eec983969eea2b54f
-  BuzzInsight: 57d7c65a2f3812696df482fc7c83d6305c3e2061
-  BuzzResource: a9d926cac0dd831ba8dbbaa9c3b6c717899b2f2f
+  BuzzAdBenefit: 41168b812b8f4b5f2e8d9f7b0684d79dfeda551e
+  BuzzAdBenefitBase: 74bcb90f9f636b81f66c0146883c06e10d26d19f
+  BuzzAdBenefitFeed: 159f39ab5a481ce31f84c7e2e08775e15e944ade
+  BuzzAdBenefitInterstitial: a593d0693ce7861fc92e89c9a63cb957c567d2cb
+  BuzzAdBenefitNative: 648e913237753f47a4043fc0c8823a9c5f90f7dd
+  BuzzBaseRewardSwift: b01b82e2535d1bcdd456cd27f8632f905e9770c6
+  BuzzCore: ea6a29b05c2faf2caeb65ab06e220c88b8f6faae
+  BuzzInsight: 9c6b8234476eded1ea1072243a63ae2e175fbac0
+  BuzzResource: 2310254cce7a560a626ea8aaeb82ace54492a9ec
   BuzzRxSwift: 0ca1668aa41a0b4a811c9eb00d74c89a95a8553f
-  BuzzServiceApi: bab4249883ef88a715a3a32307f6a8f44f7fab3f
-  BuzzUnit: 62a97b9b44b0e8d05f4b3225c4071911534b58aa
+  BuzzServiceApi: 3f4d5d6aec165a41ee84c0e9fec8809d52235f5e
+  BuzzUnit: b638e74c58454539a4b5846c746d1ac31b7e09bd
   GoogleAds-IMA-iOS-SDK: b088674002266c5638e73d10696c8b13872ee15e
   libwebp: f62cb61d0a484ba548448a4bd52aabf150ff6eef
   ReactiveObjC: 011caa393aa0383245f2dcf9bf02e86b80b36040
@@ -130,6 +130,6 @@ SPEC CHECKSUMS:
   SDWebImageWebPCoder: 4851414d9f8894e328e8b97c93ea4f4f4e4418ae
   Toast: 91b396c56ee72a5790816f40d3a94dd357abc196
 
-PODFILE CHECKSUM: 74f42728b2840d63aa416fabcd4b8ee0ee43465b
+PODFILE CHECKSUM: 693abfa0805cf515503474b8ae853362896e5448
 
 COCOAPODS: 1.11.3

--- a/buzzad-benefit-ios/README.md
+++ b/buzzad-benefit-ios/README.md
@@ -6,6 +6,16 @@
 ### 오픈 소스 라이센스 고지
 - 이 소프트웨어가 사용하는 오픈 소스 소프트웨어의 라이센스는 "오픈 소스 라이센스 고지 페이지 ([원본 파일](docs/3rd_party_licenses.html)|[렌더링 버전](https://htmlpreview.github.io/?https://github.com/Buzzvil/buzzscreen-sdk-publisher/blob/master/docs/3rd_party_licenses.html))"에서 확인할 수 있다.
 
+## [3.23.3] - 2023-02-28
+* [NEW] 피드에 캐러셀 배너 영역 추가
+* [UPDATE] 활동 추적 권한 허용을 유도하는 배너 디자인 개선
+* [FIX] 대시에서 피드 광고 분류 탭을 비활성화한 상태에서 광고 분류 필터만 활성화하면 발생하는 문제 해결
+  * 필터가 제대로 나타나지 않아 유저가 참여하고 싶은 광고의 세부 유형을 선택할 수 없는 문제 해결
+  * 광고 프리로드를 실패하는 문제 해결
+* [FIX] 광고 뷰를 자체 구현한 경우 발생하는 UI 오류 해결 (예: 유저의 광고 참여 상태에 따라 CTA 뷰가 업데이트되지 않은 문제)
+* [FIX] CTA 버튼 커스터마이징이 잘 동작하지 않는 버그 수정
+* 자세한 사항은 [링크](https://docs.buzzvil.com/docs/release-news/ios/buzzad3.23/) 참조
+
 ## [3.21.2] - 2023-01-26
 * [CHANGE] Xcode 14에서 BuzzAd iOS SDK를 사용할 때 Warning이 발생하지 않도록 Minimum deployment target을 11로 상향
 * [NEW] 커스텀 인앱 브라우저 사용 시 딥링크 광고 여부를 확인하는 인터페이스 추가


### PR DESCRIPTION
퍼블릭 샘플 애플리케이션의 BuzzAd iOS SDK 버전을 3.23.3 으로 업데이트 합니다.