### PR TITLE
BuzzAd iOS SDK 3.29.1

### DIFF
--- a/buzzad-benefit-ios/Podfile
+++ b/buzzad-benefit-ios/Podfile
@@ -8,7 +8,7 @@ inhibit_all_warnings!
 deployment_target = '11.0'
 
 target 'BABSample' do
-  pod 'BuzzAdBenefit', '~> 3.27.4'
+  pod 'BuzzAdBenefit', '~> 3.29.1'
   pod 'Toast', '~> 4.0.0'
 end
 

--- a/buzzad-benefit-ios/Podfile.lock
+++ b/buzzad-benefit-ios/Podfile.lock
@@ -14,51 +14,48 @@ PODS:
   - AFNetworking/Serialization (4.0.1)
   - AFNetworking/UIKit (4.0.1):
     - AFNetworking/NSURLSession
-  - BuzzAdBenefit (3.27.4):
-    - BuzzAdBenefitBase (~> 3.27.4)
-    - BuzzAdBenefitFeed (~> 3.27.4)
-    - BuzzAdBenefitInterstitial (~> 3.27.4)
-    - BuzzAdBenefitNative (~> 3.27.4)
-  - BuzzAdBenefitBase (3.27.4):
+  - BuzzAdBenefit (3.29.1):
+    - BuzzAdBenefitBase (~> 3.29.1)
+    - BuzzAdBenefitFeed (~> 3.29.1)
+    - BuzzAdBenefitInterstitial (~> 3.29.1)
+    - BuzzAdBenefitNative (~> 3.29.1)
+  - BuzzAdBenefitBase (3.29.1):
     - AFNetworking (~> 4.0)
-    - BuzzBaseRewardSwift (~> 0.31.4)
-    - BuzzInsight (~> 0.31.4)
-    - BuzzResource (~> 0.31.4)
+    - BuzzInsight (~> 0.33.1)
+    - BuzzResource (~> 0.33.1)
     - BuzzRxSwift (~> 6.5.1)
-    - BuzzServiceApi (~> 0.31.4)
-    - BuzzUnit (~> 0.31.4)
+    - BuzzServiceApi (~> 0.33.1)
+    - BuzzUnit (~> 0.33.1)
     - ReactiveObjC (~> 3.1.1)
     - SDWebImage (~> 5.0)
     - SDWebImageWebPCoder
-  - BuzzAdBenefitFeed (3.27.4):
-    - BuzzAdBenefitBase (~> 3.27.4)
-    - BuzzAdBenefitNative (~> 3.27.4)
-    - BuzzResource (~> 0.31.4)
+  - BuzzAdBenefitFeed (3.29.1):
+    - BuzzAdBenefitBase (~> 3.29.1)
+    - BuzzAdBenefitNative (~> 3.29.1)
+    - BuzzResource (~> 0.33.1)
     - BuzzRxSwift (~> 6.5.1)
-    - BuzzServiceApi (~> 0.31.4)
+    - BuzzServiceApi (~> 0.33.1)
     - ReactiveObjC (~> 3.1.1)
-  - BuzzAdBenefitInterstitial (3.27.4):
-    - BuzzAdBenefitBase (~> 3.27.4)
-    - BuzzAdBenefitNative (~> 3.27.4)
+  - BuzzAdBenefitInterstitial (3.29.1):
+    - BuzzAdBenefitBase (~> 3.29.1)
+    - BuzzAdBenefitNative (~> 3.29.1)
     - ReactiveObjC (~> 3.1.1)
-  - BuzzAdBenefitNative (3.27.4):
-    - BuzzAdBenefitBase (~> 3.27.4)
-    - BuzzResource (~> 0.31.4)
+  - BuzzAdBenefitNative (3.29.1):
+    - BuzzAdBenefitBase (~> 3.29.1)
+    - BuzzResource (~> 0.33.1)
     - BuzzRxSwift (~> 6.5.1)
     - GoogleAds-IMA-iOS-SDK (~> 3.12)
     - ReactiveObjC (~> 3.1.1)
-  - BuzzBaseRewardSwift (0.31.4):
-    - BuzzRxSwift (~> 6.5.1)
-  - BuzzInsight (0.31.4):
+  - BuzzInsight (0.33.1):
     - ReactiveObjC (~> 3.1.1)
-  - BuzzResource (0.31.4)
+  - BuzzResource (0.33.1)
   - BuzzRxSwift (6.5.1)
-  - BuzzServiceApi (0.31.4):
+  - BuzzServiceApi (0.33.1):
     - ReactiveObjC (~> 3.1.1)
-  - BuzzUnit (0.31.4):
-    - BuzzServiceApi (~> 0.31.4)
+  - BuzzUnit (0.33.1):
+    - BuzzServiceApi (~> 0.33.1)
     - ReactiveObjC (~> 3.1.1)
-  - GoogleAds-IMA-iOS-SDK (3.18.5)
+  - GoogleAds-IMA-iOS-SDK (3.19.2)
   - libwebp (1.2.4):
     - libwebp/demux (= 1.2.4)
     - libwebp/mux (= 1.2.4)
@@ -69,16 +66,16 @@ PODS:
     - libwebp/demux
   - libwebp/webp (1.2.4)
   - ReactiveObjC (3.1.1)
-  - SDWebImage (5.15.5):
-    - SDWebImage/Core (= 5.15.5)
-  - SDWebImage/Core (5.15.5)
+  - SDWebImage (5.15.8):
+    - SDWebImage/Core (= 5.15.8)
+  - SDWebImage/Core (5.15.8)
   - SDWebImageWebPCoder (0.11.0):
     - libwebp (~> 1.0)
     - SDWebImage/Core (~> 5.15)
   - Toast (4.0.0)
 
 DEPENDENCIES:
-  - BuzzAdBenefit (~> 3.27.4)
+  - BuzzAdBenefit (~> 3.29.1)
   - Toast (~> 4.0.0)
 
 SPEC REPOS:
@@ -89,7 +86,6 @@ SPEC REPOS:
     - BuzzAdBenefitFeed
     - BuzzAdBenefitInterstitial
     - BuzzAdBenefitNative
-    - BuzzBaseRewardSwift
     - BuzzInsight
     - BuzzResource
     - BuzzRxSwift
@@ -104,24 +100,23 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   AFNetworking: 3bd23d814e976cd148d7d44c3ab78017b744cd58
-  BuzzAdBenefit: 82d33f5c0ead80c129e191a367fa3775d0209ad5
-  BuzzAdBenefitBase: 3ac156b36e41ccabe56ac6c64f3f57b038c4ef11
-  BuzzAdBenefitFeed: 6dcc6c70762ba46f98cf28bd3e6f2841897e37bd
-  BuzzAdBenefitInterstitial: cc79a65a4b15f27b3082bacabcfedd8090455e0b
-  BuzzAdBenefitNative: f34a6b477829f10e066eb24b459958be956b0dfe
-  BuzzBaseRewardSwift: 99477c6d1fc99e8d762d13b7827e506cfd5e6954
-  BuzzInsight: 7f14b7a9e9172185abdcb11244307f1426c60d42
-  BuzzResource: a7295d13d576d1d738cba7b3efb533112f499fb4
+  BuzzAdBenefit: 1dd607cb17fc29c06bf16936d7036ba96b093e9d
+  BuzzAdBenefitBase: 6a46121c5b880a4b1e65c5c3beb1d63ae1257a73
+  BuzzAdBenefitFeed: f4bb2f9885f1942b5104688da73768992335f73c
+  BuzzAdBenefitInterstitial: 3f1b4751f74ed3d79130140978daa87bd7898957
+  BuzzAdBenefitNative: 55607d944712abdfb326fa5cc1dbd30aa04e42c2
+  BuzzInsight: 3fad7cff972d6068e46dd966dfe2187dc8736db4
+  BuzzResource: df62f706fb02c08397815dddf3d6f179d953ae87
   BuzzRxSwift: 0ca1668aa41a0b4a811c9eb00d74c89a95a8553f
-  BuzzServiceApi: 843cef6ff333f3a305bf4f4344410282861ea6c3
-  BuzzUnit: a6fc8914dd8490b0612e8d90376de366c76edd1c
-  GoogleAds-IMA-iOS-SDK: 7dbef0755db43698f2f6a3a7ac51a88571945399
+  BuzzServiceApi: 10dce995f5c3d89442f44ebaa9f0e18202b476b4
+  BuzzUnit: 4f411d0165f1f012023beb1513e55620d1c41ec0
+  GoogleAds-IMA-iOS-SDK: 0e817c05ab26f1b9285c80f4a75e1350a916d50b
   libwebp: f62cb61d0a484ba548448a4bd52aabf150ff6eef
   ReactiveObjC: 011caa393aa0383245f2dcf9bf02e86b80b36040
-  SDWebImage: fd7e1a22f00303e058058278639bf6196ee431fe
+  SDWebImage: cb032eba469c54e0000e78bcb0a13cdde0a52798
   SDWebImageWebPCoder: 295a6573c512f54ad2dd58098e64e17dcf008499
   Toast: 91b396c56ee72a5790816f40d3a94dd357abc196
 
-PODFILE CHECKSUM: 37aece9cd7ea1ec1e999b9d8a913d9e8769ecaa9
+PODFILE CHECKSUM: c4c54151aa29df27516caebc8d151f34f5b94c6d
 
-COCOAPODS: 1.12.0
+COCOAPODS: 1.12.1


### PR DESCRIPTION
퍼블릭 샘플 애플리케이션의 BuzzAd iOS SDK 버전을 3.29.1 으로 업데이트 합니다.