### PR TITLE
BuzzAd iOS SDK 3.35.5

### DIFF
--- a/buzzad-benefit-ios/Podfile
+++ b/buzzad-benefit-ios/Podfile
@@ -8,7 +8,7 @@ inhibit_all_warnings!
 deployment_target = '11.0'
 
 target 'BABSample' do
-  pod 'BuzzAdBenefit', '~> 3.33.1'
+  pod 'BuzzAdBenefit', '~> 3.35.5'
   pod 'Toast', '~> 4.0.0'
 end
 

--- a/buzzad-benefit-ios/Podfile.lock
+++ b/buzzad-benefit-ios/Podfile.lock
@@ -14,53 +14,57 @@ PODS:
   - AFNetworking/Serialization (4.0.1)
   - AFNetworking/UIKit (4.0.1):
     - AFNetworking/NSURLSession
-  - BuzzAdBenefit (3.33.1):
-    - BuzzAdBenefitBase (~> 3.33.1)
-    - BuzzAdBenefitFeed (~> 3.33.1)
-    - BuzzAdBenefitInterstitial (~> 3.33.1)
-    - BuzzAdBenefitNative (~> 3.33.1)
-  - BuzzAdBenefitBase (3.33.1):
+  - BuzzAdBenefit (3.35.5):
+    - BuzzAdBenefitBase (~> 3.35.5)
+    - BuzzAdBenefitFeed (~> 3.35.5)
+    - BuzzAdBenefitInterstitial (~> 3.35.5)
+    - BuzzAdBenefitNative (~> 3.35.5)
+  - BuzzAdBenefitBase (3.35.5):
     - AFNetworking (~> 4.0)
     - BuzzRxSwift (~> 6.5.1)
     - ReactiveObjC (~> 3.1.1)
     - SDWebImage (~> 5.0)
     - SDWebImageWebPCoder
-  - BuzzAdBenefitFeed (3.33.1):
-    - BuzzAdBenefitBase (~> 3.33.1)
-    - BuzzAdBenefitNative (~> 3.33.1)
+  - BuzzAdBenefitFeed (3.35.5):
+    - BuzzAdBenefitBase (~> 3.35.5)
+    - BuzzAdBenefitInterstitial (~> 3.35.5)
+    - BuzzAdBenefitNative (~> 3.35.5)
     - BuzzRxSwift (~> 6.5.1)
     - ReactiveObjC (~> 3.1.1)
-  - BuzzAdBenefitInterstitial (3.33.1):
-    - BuzzAdBenefitBase (~> 3.33.1)
-    - BuzzAdBenefitNative (~> 3.33.1)
-    - ReactiveObjC (~> 3.1.1)
-  - BuzzAdBenefitNative (3.33.1):
-    - BuzzAdBenefitBase (~> 3.33.1)
+  - BuzzAdBenefitInterstitial (3.35.5):
+    - BuzzAdBenefitBase (~> 3.35.5)
+    - BuzzAdBenefitNative (~> 3.35.5)
+    - BuzzRxSwift (~> 6.5.1)
+  - BuzzAdBenefitNative (3.35.5):
+    - BuzzAdBenefitBase (~> 3.35.5)
     - BuzzRxSwift (~> 6.5.1)
     - GoogleAds-IMA-iOS-SDK (~> 3.12)
     - ReactiveObjC (~> 3.1.1)
   - BuzzRxSwift (6.5.1)
   - GoogleAds-IMA-iOS-SDK (3.19.2)
-  - libwebp (1.2.4):
-    - libwebp/demux (= 1.2.4)
-    - libwebp/mux (= 1.2.4)
-    - libwebp/webp (= 1.2.4)
-  - libwebp/demux (1.2.4):
+  - libwebp (1.3.1):
+    - libwebp/demux (= 1.3.1)
+    - libwebp/mux (= 1.3.1)
+    - libwebp/sharpyuv (= 1.3.1)
+    - libwebp/webp (= 1.3.1)
+  - libwebp/demux (1.3.1):
     - libwebp/webp
-  - libwebp/mux (1.2.4):
+  - libwebp/mux (1.3.1):
     - libwebp/demux
-  - libwebp/webp (1.2.4)
+  - libwebp/sharpyuv (1.3.1)
+  - libwebp/webp (1.3.1):
+    - libwebp/sharpyuv
   - ReactiveObjC (3.1.1)
-  - SDWebImage (5.16.0):
-    - SDWebImage/Core (= 5.16.0)
-  - SDWebImage/Core (5.16.0)
-  - SDWebImageWebPCoder (0.12.0):
+  - SDWebImage (5.17.0):
+    - SDWebImage/Core (= 5.17.0)
+  - SDWebImage/Core (5.17.0)
+  - SDWebImageWebPCoder (0.13.0):
     - libwebp (~> 1.0)
-    - SDWebImage/Core (~> 5.16)
+    - SDWebImage/Core (~> 5.17)
   - Toast (4.0.0)
 
 DEPENDENCIES:
-  - BuzzAdBenefit (~> 3.33.1)
+  - BuzzAdBenefit (~> 3.35.5)
   - Toast (~> 4.0.0)
 
 SPEC REPOS:
@@ -81,19 +85,19 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   AFNetworking: 3bd23d814e976cd148d7d44c3ab78017b744cd58
-  BuzzAdBenefit: 099c9c60afc917432afc50c3a90b947f03c0b04b
-  BuzzAdBenefitBase: 4dc6278e50a23f048a62503e5502b8f248c6f826
-  BuzzAdBenefitFeed: bba9e0da4fa21e37b59583a707c30c5c522e129e
-  BuzzAdBenefitInterstitial: 3752df3c958d8ba2ba4dfec2fda8c6b604dbfb0c
-  BuzzAdBenefitNative: 8882253bb9cf9d421474596859ae38c675cfe871
+  BuzzAdBenefit: 2ef731fce432994f9d108968cc2c7ad35b650f36
+  BuzzAdBenefitBase: 751cefd9620c3db542b250934688015b19467034
+  BuzzAdBenefitFeed: f84912e8de5f8643b3d9c0bc0903c99652492cbb
+  BuzzAdBenefitInterstitial: a0db74a47d7b3fccb6d547ee3e9236910ef16615
+  BuzzAdBenefitNative: 2b4514977a0144e2f1d5e8c3ed1d5e3c2690834c
   BuzzRxSwift: 0ca1668aa41a0b4a811c9eb00d74c89a95a8553f
   GoogleAds-IMA-iOS-SDK: 0e817c05ab26f1b9285c80f4a75e1350a916d50b
-  libwebp: f62cb61d0a484ba548448a4bd52aabf150ff6eef
+  libwebp: 33dc822fbbf4503668d09f7885bbfedc76c45e96
   ReactiveObjC: 011caa393aa0383245f2dcf9bf02e86b80b36040
-  SDWebImage: 2aea163b50bfcb569a2726b6a754c54a4506fcf6
-  SDWebImageWebPCoder: f0f287cee4cd96a59937fbf3c77a8cfda9ba67b0
+  SDWebImage: 750adf017a315a280c60fde706ab1e552a3ae4e9
+  SDWebImageWebPCoder: af09429398d99d524cae2fe00f6f0f6e491ed102
   Toast: 91b396c56ee72a5790816f40d3a94dd357abc196
 
-PODFILE CHECKSUM: 8c28e57208986be322bc732628c8205141fbad04
+PODFILE CHECKSUM: 7152ec863c3686a03704d491487c9d8cc0cf5f19
 
 COCOAPODS: 1.12.1

--- a/buzzad-benefit-ios/README.md
+++ b/buzzad-benefit-ios/README.md
@@ -6,6 +6,10 @@
 ### 오픈 소스 라이센스 고지
 - 이 소프트웨어가 사용하는 오픈 소스 소프트웨어의 라이센스는 "오픈 소스 라이센스 고지 페이지 ([원본 파일](docs/3rd_party_licenses.html)|[렌더링 버전](https://htmlpreview.github.io/?https://github.com/Buzzvil/buzzscreen-sdk-publisher/blob/master/docs/3rd_party_licenses.html))"에서 확인할 수 있다.
 
+## [3.35.5] - 2023-08-17
+* [UPDATE] 애드허브 광고 미할당 UX & UI 개선​
+* 자세한 사항은 [링크](https://docs.buzzvil.com/docs/release-news/ios/buzzad3.35/) 참조
+
 ## [3.33.1] - 2023-07-13
 * [FIX] 동영상 광고 재생이 완료된 후 나타나는 “더보기“ 버튼의 URL이 호출되지 않는 문제 해결
 * 자세한 사항은 [링크](https://docs.buzzvil.com/docs/release-news/ios/buzzad3.33/) 참조


### PR DESCRIPTION
퍼블릭 샘플 애플리케이션의 BuzzAd iOS SDK 버전을 3.35.5 으로 업데이트 합니다.