### PR TITLE
BuzzAd iOS SDK 3.37.1

### DIFF
--- a/buzzad-benefit-ios/Podfile
+++ b/buzzad-benefit-ios/Podfile
@@ -8,7 +8,7 @@ inhibit_all_warnings!
 deployment_target = '11.0'
 
 target 'BABSample' do
-  pod 'BuzzAdBenefit', '~> 3.35.5'
+  pod 'BuzzAdBenefit', '~> 3.37.1'
   pod 'Toast', '~> 4.0.0'
 end
 

--- a/buzzad-benefit-ios/Podfile.lock
+++ b/buzzad-benefit-ios/Podfile.lock
@@ -14,29 +14,29 @@ PODS:
   - AFNetworking/Serialization (4.0.1)
   - AFNetworking/UIKit (4.0.1):
     - AFNetworking/NSURLSession
-  - BuzzAdBenefit (3.35.5):
-    - BuzzAdBenefitBase (~> 3.35.5)
-    - BuzzAdBenefitFeed (~> 3.35.5)
-    - BuzzAdBenefitInterstitial (~> 3.35.5)
-    - BuzzAdBenefitNative (~> 3.35.5)
-  - BuzzAdBenefitBase (3.35.5):
+  - BuzzAdBenefit (3.37.1):
+    - BuzzAdBenefitBase (~> 3.37.1)
+    - BuzzAdBenefitFeed (~> 3.37.1)
+    - BuzzAdBenefitInterstitial (~> 3.37.1)
+    - BuzzAdBenefitNative (~> 3.37.1)
+  - BuzzAdBenefitBase (3.37.1):
     - AFNetworking (~> 4.0)
     - BuzzRxSwift (~> 6.5.1)
     - ReactiveObjC (~> 3.1.1)
     - SDWebImage (~> 5.0)
     - SDWebImageWebPCoder
-  - BuzzAdBenefitFeed (3.35.5):
-    - BuzzAdBenefitBase (~> 3.35.5)
-    - BuzzAdBenefitInterstitial (~> 3.35.5)
-    - BuzzAdBenefitNative (~> 3.35.5)
+  - BuzzAdBenefitFeed (3.37.1):
+    - BuzzAdBenefitBase (~> 3.37.1)
+    - BuzzAdBenefitInterstitial (~> 3.37.1)
+    - BuzzAdBenefitNative (~> 3.37.1)
     - BuzzRxSwift (~> 6.5.1)
     - ReactiveObjC (~> 3.1.1)
-  - BuzzAdBenefitInterstitial (3.35.5):
-    - BuzzAdBenefitBase (~> 3.35.5)
-    - BuzzAdBenefitNative (~> 3.35.5)
+  - BuzzAdBenefitInterstitial (3.37.1):
+    - BuzzAdBenefitBase (~> 3.37.1)
+    - BuzzAdBenefitNative (~> 3.37.1)
     - BuzzRxSwift (~> 6.5.1)
-  - BuzzAdBenefitNative (3.35.5):
-    - BuzzAdBenefitBase (~> 3.35.5)
+  - BuzzAdBenefitNative (3.37.1):
+    - BuzzAdBenefitBase (~> 3.37.1)
     - BuzzRxSwift (~> 6.5.1)
     - GoogleAds-IMA-iOS-SDK (~> 3.12)
     - ReactiveObjC (~> 3.1.1)
@@ -55,16 +55,16 @@ PODS:
   - libwebp/webp (1.3.1):
     - libwebp/sharpyuv
   - ReactiveObjC (3.1.1)
-  - SDWebImage (5.17.0):
-    - SDWebImage/Core (= 5.17.0)
-  - SDWebImage/Core (5.17.0)
+  - SDWebImage (5.18.0):
+    - SDWebImage/Core (= 5.18.0)
+  - SDWebImage/Core (5.18.0)
   - SDWebImageWebPCoder (0.13.0):
     - libwebp (~> 1.0)
     - SDWebImage/Core (~> 5.17)
   - Toast (4.0.0)
 
 DEPENDENCIES:
-  - BuzzAdBenefit (~> 3.35.5)
+  - BuzzAdBenefit (~> 3.37.1)
   - Toast (~> 4.0.0)
 
 SPEC REPOS:
@@ -85,19 +85,19 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   AFNetworking: 3bd23d814e976cd148d7d44c3ab78017b744cd58
-  BuzzAdBenefit: 2ef731fce432994f9d108968cc2c7ad35b650f36
-  BuzzAdBenefitBase: 751cefd9620c3db542b250934688015b19467034
-  BuzzAdBenefitFeed: f84912e8de5f8643b3d9c0bc0903c99652492cbb
-  BuzzAdBenefitInterstitial: a0db74a47d7b3fccb6d547ee3e9236910ef16615
-  BuzzAdBenefitNative: 2b4514977a0144e2f1d5e8c3ed1d5e3c2690834c
+  BuzzAdBenefit: 6db15aa0ae7740d0776f97b052e01a4d0cd3df4c
+  BuzzAdBenefitBase: 4025a410aab3283251cdd4d956a31e75f9ade840
+  BuzzAdBenefitFeed: b0d0aa76feffcf21093ec8784bf61c04a3156f92
+  BuzzAdBenefitInterstitial: 5694fe74345686083b0bf2582a813f9b3082f193
+  BuzzAdBenefitNative: 34ba544c5444135eb4ba31591756dd97a0fa4481
   BuzzRxSwift: 0ca1668aa41a0b4a811c9eb00d74c89a95a8553f
   GoogleAds-IMA-iOS-SDK: 0e817c05ab26f1b9285c80f4a75e1350a916d50b
   libwebp: 33dc822fbbf4503668d09f7885bbfedc76c45e96
   ReactiveObjC: 011caa393aa0383245f2dcf9bf02e86b80b36040
-  SDWebImage: 750adf017a315a280c60fde706ab1e552a3ae4e9
+  SDWebImage: 182830bcddc30cde95fbc60dfe4badc3553d94ba
   SDWebImageWebPCoder: af09429398d99d524cae2fe00f6f0f6e491ed102
   Toast: 91b396c56ee72a5790816f40d3a94dd357abc196
 
-PODFILE CHECKSUM: 7152ec863c3686a03704d491487c9d8cc0cf5f19
+PODFILE CHECKSUM: 216f2d26488b10ea1d2476fdd30e60b4233ddeb7
 
 COCOAPODS: 1.12.1

--- a/buzzad-benefit-ios/README.md
+++ b/buzzad-benefit-ios/README.md
@@ -6,6 +6,10 @@
 ### 오픈 소스 라이센스 고지
 - 이 소프트웨어가 사용하는 오픈 소스 소프트웨어의 라이센스는 "오픈 소스 라이센스 고지 페이지 ([원본 파일](docs/3rd_party_licenses.html)|[렌더링 버전](https://htmlpreview.github.io/?https://github.com/Buzzvil/buzzscreen-sdk-publisher/blob/master/docs/3rd_party_licenses.html))"에서 확인할 수 있다.
 
+## [3.37.1] - 2023-09-07
+* [NEW] 애드허브 유저 리텐션 증대를 위한 출석체크 기능 “데일리 리워드” 출시
+* 자세한 사항은 [링크](https://docs.buzzvil.com/docs/release-news/ios/buzzad3.37/) 참조
+
 ## [3.35.5] - 2023-08-17
 * [UPDATE] 애드허브 광고 미할당 UX & UI 개선​
 * 자세한 사항은 [링크](https://docs.buzzvil.com/docs/release-news/ios/buzzad3.35/) 참조


### PR DESCRIPTION
퍼블릭 샘플 애플리케이션의 BuzzAd iOS SDK 버전을 3.37.1 으로 업데이트 합니다.