### PR TITLE
[OUTPUT-2964] Fix path for 3rd party licenses

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Sample apps for publisher	
 
 ## Open Source License Announcement	
-- [Original file](./3rd_party_licenses.html)|[Rendered page](https://htmlpreview.github.io/?https://github.com/Buzzvil/buzz-sdk-samples/blob/master/3rd_party_licenses.html)	
+- [Original file](/3rd_party_licenses.html)|[Rendered page](https://htmlpreview.github.io/?https://github.com/Buzzvil/buzz-sdk-samples/blob/master/3rd_party_licenses.html)	
 
 
 ## 1. buzzad-benefit	

--- a/buzzad-benefit-ios/README.md
+++ b/buzzad-benefit-ios/README.md
@@ -4,7 +4,7 @@
 * [개발 가이드](https://docs.buzzvil.com/)
 
 ### 오픈 소스 라이센스 고지
-- 이 소프트웨어가 사용하는 오픈 소스 소프트웨어의 라이센스는 "오픈 소스 라이센스 고지 페이지 ([원본 파일](/3rd_party_licenses.html)|[렌더링 버전](https://htmlpreview.github.io/?https://github.com/Buzzvil/buzzscreen-sdk-publisher/blob/master/docs/3rd_party_licenses.html))"에서 확인할 수 있다.
+- 이 소프트웨어가 사용하는 오픈 소스 소프트웨어의 라이센스는 "오픈 소스 라이센스 고지 페이지 ([원본 파일](/3rd_party_licenses.html)|[렌더링 버전](https://htmlpreview.github.io/?https://github.com/Buzzvil/buzz-sdk-samples/blob/master/3rd_party_licenses.html))"에서 확인할 수 있다.
 
 ## [3.41.0] - 2023-11-02
 * [FIX] 버그 수정

--- a/buzzad-benefit-ios/README.md
+++ b/buzzad-benefit-ios/README.md
@@ -4,7 +4,7 @@
 * [개발 가이드](https://docs.buzzvil.com/)
 
 ### 오픈 소스 라이센스 고지
-- 이 소프트웨어가 사용하는 오픈 소스 소프트웨어의 라이센스는 "오픈 소스 라이센스 고지 페이지 ([원본 파일](docs/3rd_party_licenses.html)|[렌더링 버전](https://htmlpreview.github.io/?https://github.com/Buzzvil/buzzscreen-sdk-publisher/blob/master/docs/3rd_party_licenses.html))"에서 확인할 수 있다.
+- 이 소프트웨어가 사용하는 오픈 소스 소프트웨어의 라이센스는 "오픈 소스 라이센스 고지 페이지 ([원본 파일](/3rd_party_licenses.html)|[렌더링 버전](https://htmlpreview.github.io/?https://github.com/Buzzvil/buzzscreen-sdk-publisher/blob/master/docs/3rd_party_licenses.html))"에서 확인할 수 있다.
 
 ## [3.41.0] - 2023-11-02
 * [FIX] 버그 수정

--- a/buzzad-benefit/README.md
+++ b/buzzad-benefit/README.md
@@ -4,7 +4,7 @@
 * [개발 가이드](https://buzzvil.atlassian.net/wiki/spaces/BDG/pages/718569580/BuzzAd+Benefit)
 
 ### 오픈 소스 라이센스 고지
-- 이 소프트웨어가 사용하는 오픈 소스 소프트웨어의 라이센스는 "오픈 소스 라이센스 고지 페이지 ([원본 파일](docs/3rd_party_licenses.html)|[렌더링 버전](https://htmlpreview.github.io/?https://github.com/Buzzvil/buzzscreen-sdk-publisher/blob/master/docs/3rd_party_licenses.html))"에서 확인할 수 있다.
+- 이 소프트웨어가 사용하는 오픈 소스 소프트웨어의 라이센스는 "오픈 소스 라이센스 고지 페이지 ([원본 파일](/3rd_party_licenses.html)|[렌더링 버전](https://htmlpreview.github.io/?https://github.com/Buzzvil/buzzscreen-sdk-publisher/blob/master/docs/3rd_party_licenses.html))"에서 확인할 수 있다.
 
 ## [3.49.0] - 2023-11-30
 * [UPDATE] 연동 과정 중에 문제가 발생하여 서비스 제공에 문제가 생길 때 전달되는 UNKNOWN 오류 코드에 대한 화면을 추가했습니다.

--- a/buzzad-benefit/README.md
+++ b/buzzad-benefit/README.md
@@ -4,7 +4,7 @@
 * [개발 가이드](https://buzzvil.atlassian.net/wiki/spaces/BDG/pages/718569580/BuzzAd+Benefit)
 
 ### 오픈 소스 라이센스 고지
-- 이 소프트웨어가 사용하는 오픈 소스 소프트웨어의 라이센스는 "오픈 소스 라이센스 고지 페이지 ([원본 파일](/3rd_party_licenses.html)|[렌더링 버전](https://htmlpreview.github.io/?https://github.com/Buzzvil/buzzscreen-sdk-publisher/blob/master/docs/3rd_party_licenses.html))"에서 확인할 수 있다.
+- 이 소프트웨어가 사용하는 오픈 소스 소프트웨어의 라이센스는 "오픈 소스 라이센스 고지 페이지 ([원본 파일](/3rd_party_licenses.html)|[렌더링 버전](https://htmlpreview.github.io/?https://github.com/Buzzvil/buzz-sdk-samples/blob/master/3rd_party_licenses.html))"에서 확인할 수 있다.
 
 ## [3.49.0] - 2023-11-30
 * [UPDATE] 연동 과정 중에 문제가 발생하여 서비스 제공에 문제가 생길 때 전달되는 UNKNOWN 오류 코드에 대한 화면을 추가했습니다.

--- a/buzzbooster-android/README.md
+++ b/buzzbooster-android/README.md
@@ -11,4 +11,4 @@
 - `app/src/main/java/com/buzzvil/booster/sample/publisher/App.kt` 파일을 열어서 `APP_KEY`를 원하는 app key로 변경할 수 있습니다.
 
 ### 오픈 소스 라이센스 고지
-- 이 소프트웨어가 사용하는 오픈 소스 소프트웨어의 라이센스는 "오픈 소스 라이센스 고지 페이지 ([원본 파일](../3rd_party_licenses.html)|[렌더링 버전](https://htmlpreview.github.io/?https://github.com/Buzzvil/buzz-sdk-samples/blob/master/3rd_party_licenses.html))"에서 확인할 수 있다.
+- 이 소프트웨어가 사용하는 오픈 소스 소프트웨어의 라이센스는 "오픈 소스 라이센스 고지 페이지 ([원본 파일](/3rd_party_licenses.html)|[렌더링 버전](https://htmlpreview.github.io/?https://github.com/Buzzvil/buzz-sdk-samples/blob/master/3rd_party_licenses.html))"에서 확인할 수 있다.

--- a/buzzbooster-android/README.md
+++ b/buzzbooster-android/README.md
@@ -11,4 +11,4 @@
 - `app/src/main/java/com/buzzvil/booster/sample/publisher/App.kt` 파일을 열어서 `APP_KEY`를 원하는 app key로 변경할 수 있습니다.
 
 ### 오픈 소스 라이센스 고지
-- 이 소프트웨어가 사용하는 오픈 소스 소프트웨어의 라이센스는 "오픈 소스 라이센스 고지 페이지 ([원본 파일](../3rd_party_licenses.html)|[렌더링 버전](https://htmlpreview.github.io/?https://github.com/Buzzvil/buzzscreen-sdk-publisher/blob/master/docs/3rd_party_licenses.html))"에서 확인할 수 있다.
+- 이 소프트웨어가 사용하는 오픈 소스 소프트웨어의 라이센스는 "오픈 소스 라이센스 고지 페이지 ([원본 파일](../3rd_party_licenses.html)|[렌더링 버전](https://htmlpreview.github.io/?https://github.com/Buzzvil/buzz-sdk-samples/blob/master/3rd_party_licenses.html))"에서 확인할 수 있다.

--- a/buzzbooster-flutter/README.md
+++ b/buzzbooster-flutter/README.md
@@ -16,4 +16,4 @@ flutter run
 ```
 
 ### 오픈 소스 라이센스 고지
-- 이 소프트웨어가 사용하는 오픈 소스 소프트웨어의 라이센스는 "오픈 소스 라이센스 고지 페이지 ([원본 파일](../3rd_party_licenses.html)|[렌더링 버전](https://htmlpreview.github.io/?https://github.com/Buzzvil/buzz-sdk-samples/blob/master/3rd_party_licenses.html))"에서 확인할 수 있다.
+- 이 소프트웨어가 사용하는 오픈 소스 소프트웨어의 라이센스는 "오픈 소스 라이센스 고지 페이지 ([원본 파일](/3rd_party_licenses.html)|[렌더링 버전](https://htmlpreview.github.io/?https://github.com/Buzzvil/buzz-sdk-samples/blob/master/3rd_party_licenses.html))"에서 확인할 수 있다.

--- a/buzzbooster-flutter/README.md
+++ b/buzzbooster-flutter/README.md
@@ -16,4 +16,4 @@ flutter run
 ```
 
 ### 오픈 소스 라이센스 고지
-- 이 소프트웨어가 사용하는 오픈 소스 소프트웨어의 라이센스는 "오픈 소스 라이센스 고지 페이지 ([원본 파일](../3rd_party_licenses.html)|[렌더링 버전](https://htmlpreview.github.io/?https://github.com/Buzzvil/buzzscreen-sdk-publisher/blob/master/docs/3rd_party_licenses.html))"에서 확인할 수 있다.
+- 이 소프트웨어가 사용하는 오픈 소스 소프트웨어의 라이센스는 "오픈 소스 라이센스 고지 페이지 ([원본 파일](../3rd_party_licenses.html)|[렌더링 버전](https://htmlpreview.github.io/?https://github.com/Buzzvil/buzz-sdk-samples/blob/master/3rd_party_licenses.html))"에서 확인할 수 있다.

--- a/buzzbooster-ios/README.md
+++ b/buzzbooster-ios/README.md
@@ -11,4 +11,4 @@
 - `BSTSample/AppDelegate.swift` 파일을 열어서 `APP_KEY`를 원하는 app key로 변경할 수 있습니다.
 
 ### 오픈 소스 라이센스 고지
-- 이 소프트웨어가 사용하는 오픈 소스 소프트웨어의 라이센스는 "오픈 소스 라이센스 고지 페이지 ([원본 파일](../3rd_party_licenses.html)|[렌더링 버전](https://htmlpreview.github.io/?https://github.com/Buzzvil/buzz-sdk-samples/blob/master/3rd_party_licenses.html))"에서 확인할 수 있다.
+- 이 소프트웨어가 사용하는 오픈 소스 소프트웨어의 라이센스는 "오픈 소스 라이센스 고지 페이지 ([원본 파일](/3rd_party_licenses.html)|[렌더링 버전](https://htmlpreview.github.io/?https://github.com/Buzzvil/buzz-sdk-samples/blob/master/3rd_party_licenses.html))"에서 확인할 수 있다.

--- a/buzzbooster-ios/README.md
+++ b/buzzbooster-ios/README.md
@@ -11,4 +11,4 @@
 - `BSTSample/AppDelegate.swift` 파일을 열어서 `APP_KEY`를 원하는 app key로 변경할 수 있습니다.
 
 ### 오픈 소스 라이센스 고지
-- 이 소프트웨어가 사용하는 오픈 소스 소프트웨어의 라이센스는 "오픈 소스 라이센스 고지 페이지 ([원본 파일](../3rd_party_licenses.html)|[렌더링 버전](https://htmlpreview.github.io/?https://github.com/Buzzvil/buzzscreen-sdk-publisher/blob/master/docs/3rd_party_licenses.html))"에서 확인할 수 있다.
+- 이 소프트웨어가 사용하는 오픈 소스 소프트웨어의 라이센스는 "오픈 소스 라이센스 고지 페이지 ([원본 파일](../3rd_party_licenses.html)|[렌더링 버전](https://htmlpreview.github.io/?https://github.com/Buzzvil/buzz-sdk-samples/blob/master/3rd_party_licenses.html))"에서 확인할 수 있다.

--- a/buzzbooster-react-native/README.md
+++ b/buzzbooster-react-native/README.md
@@ -20,4 +20,4 @@ npx react-native run-ios
 ```
 
 ### 오픈 소스 라이센스 고지
-- 이 소프트웨어가 사용하는 오픈 소스 소프트웨어의 라이센스는 "오픈 소스 라이센스 고지 페이지 ([원본 파일](../3rd_party_licenses.html)|[렌더링 버전](https://htmlpreview.github.io/?https://github.com/Buzzvil/buzzscreen-sdk-publisher/blob/master/docs/3rd_party_licenses.html))"에서 확인할 수 있다.
+- 이 소프트웨어가 사용하는 오픈 소스 소프트웨어의 라이센스는 "오픈 소스 라이센스 고지 페이지 ([원본 파일](../3rd_party_licenses.html)|[렌더링 버전](https://htmlpreview.github.io/?https://github.com/Buzzvil/buzz-sdk-samples/blob/master/3rd_party_licenses.html))"에서 확인할 수 있다.

--- a/buzzbooster-react-native/README.md
+++ b/buzzbooster-react-native/README.md
@@ -20,4 +20,4 @@ npx react-native run-ios
 ```
 
 ### 오픈 소스 라이센스 고지
-- 이 소프트웨어가 사용하는 오픈 소스 소프트웨어의 라이센스는 "오픈 소스 라이센스 고지 페이지 ([원본 파일](../3rd_party_licenses.html)|[렌더링 버전](https://htmlpreview.github.io/?https://github.com/Buzzvil/buzz-sdk-samples/blob/master/3rd_party_licenses.html))"에서 확인할 수 있다.
+- 이 소프트웨어가 사용하는 오픈 소스 소프트웨어의 라이센스는 "오픈 소스 라이센스 고지 페이지 ([원본 파일](/3rd_party_licenses.html)|[렌더링 버전](https://htmlpreview.github.io/?https://github.com/Buzzvil/buzz-sdk-samples/blob/master/3rd_party_licenses.html))"에서 확인할 수 있다.

--- a/buzzscreen/README.md
+++ b/buzzscreen/README.md
@@ -4,7 +4,7 @@
 * [개발 가이드](https://buzzvil.atlassian.net/wiki/spaces/BDG/pages/717422763/BuzzScreen)
 
 ### 오픈 소스 라이센스 고지
-- 이 소프트웨어가 사용하는 오픈 소스 소프트웨어의 라이센스는 "오픈 소스 라이센스 고지 페이지 ([원본 파일](docs/3rd_party_licenses.html)|[렌더링 버전](https://htmlpreview.github.io/?https://github.com/Buzzvil/buzzscreen-sdk-publisher/blob/master/docs/3rd_party_licenses.html))"에서 확인할 수 있다.
+- 이 소프트웨어가 사용하는 오픈 소스 소프트웨어의 라이센스는 "오픈 소스 라이센스 고지 페이지 ([원본 파일](/3rd_party_licenses.html)|[렌더링 버전](https://htmlpreview.github.io/?https://github.com/Buzzvil/buzzscreen-sdk-publisher/blob/master/docs/3rd_party_licenses.html))"에서 확인할 수 있다.
 
 ## [4.43.0] - 2023-11-30
 * [FIX] 버그 수정

--- a/buzzscreen/README.md
+++ b/buzzscreen/README.md
@@ -4,7 +4,7 @@
 * [개발 가이드](https://buzzvil.atlassian.net/wiki/spaces/BDG/pages/717422763/BuzzScreen)
 
 ### 오픈 소스 라이센스 고지
-- 이 소프트웨어가 사용하는 오픈 소스 소프트웨어의 라이센스는 "오픈 소스 라이센스 고지 페이지 ([원본 파일](/3rd_party_licenses.html)|[렌더링 버전](https://htmlpreview.github.io/?https://github.com/Buzzvil/buzzscreen-sdk-publisher/blob/master/docs/3rd_party_licenses.html))"에서 확인할 수 있다.
+- 이 소프트웨어가 사용하는 오픈 소스 소프트웨어의 라이센스는 "오픈 소스 라이센스 고지 페이지 ([원본 파일](/3rd_party_licenses.html)|[렌더링 버전](https://htmlpreview.github.io/?https://github.com/Buzzvil/buzz-sdk-samples/blob/master/3rd_party_licenses.html))"에서 확인할 수 있다.
 
 ## [4.43.0] - 2023-11-30
 * [FIX] 버그 수정

--- a/buzzscreen/README_EN.md
+++ b/buzzscreen/README_EN.md
@@ -2,4 +2,4 @@
 - Developer Guide: https://buzzvil.atlassian.net/wiki/spaces/BDG/pages/392462350/BuzzScreen+SDK+Basic+Usage
 
 ## Open Source Software License Notice
-_ Licenses of Open Source Software used by this software are available on the "Open Source Software License Notice ([raw file](docs/3rd_party_licenses.html)|[rendered version](https://htmlpreview.github.io/?https://github.com/Buzzvil/buzzscreen-sdk-publisher/blob/master/docs/3rd_party_licenses.html))" page.
+_ Licenses of Open Source Software used by this software are available on the "Open Source Software License Notice ([raw file](/3rd_party_licenses.html)|[rendered version](https://htmlpreview.github.io/?https://github.com/Buzzvil/buzzscreen-sdk-publisher/blob/master/docs/3rd_party_licenses.html))" page.

--- a/buzzscreen/README_EN.md
+++ b/buzzscreen/README_EN.md
@@ -2,4 +2,4 @@
 - Developer Guide: https://buzzvil.atlassian.net/wiki/spaces/BDG/pages/392462350/BuzzScreen+SDK+Basic+Usage
 
 ## Open Source Software License Notice
-_ Licenses of Open Source Software used by this software are available on the "Open Source Software License Notice ([raw file](/3rd_party_licenses.html)|[rendered version](https://htmlpreview.github.io/?https://github.com/Buzzvil/buzzscreen-sdk-publisher/blob/master/docs/3rd_party_licenses.html))" page.
+_ Licenses of Open Source Software used by this software are available on the "Open Source Software License Notice ([raw file](/3rd_party_licenses.html)|[rendered version](https://htmlpreview.github.io/?https://github.com/Buzzvil/buzz-sdk-samples/blob/master/3rd_party_licenses.html))" page.

--- a/buzzvil-sdk-ios/README.md
+++ b/buzzvil-sdk-ios/README.md
@@ -4,7 +4,7 @@
 * [개발 가이드](https://docs.buzzvil.com/)
 
 ### 오픈 소스 라이센스 고지
-- 이 소프트웨어가 사용하는 오픈 소스 소프트웨어의 라이센스는 "오픈 소스 라이센스 고지 페이지 ([원본 파일](docs/3rd_party_licenses.html)|[렌더링 버전](https://htmlpreview.github.io/?https://github.com/Buzzvil/buzzscreen-sdk-publisher/blob/master/docs/3rd_party_licenses.html))"에서 확인할 수 있다.
+- 이 소프트웨어가 사용하는 오픈 소스 소프트웨어의 라이센스는 "오픈 소스 라이센스 고지 페이지 ([원본 파일](docs/3rd_party_licenses.html)|[렌더링 버전](https://htmlpreview.github.io/?https://github.com/Buzzvil/buzz-sdk-samples/blob/master/3rd_party_licenses.html))"에서 확인할 수 있다.
 
 ## [5.1.0] - 2023-11-30
 * [UPDATE] 인터스티셜 디자인 업데이트

--- a/buzzvil-sdk-ios/README.md
+++ b/buzzvil-sdk-ios/README.md
@@ -4,7 +4,7 @@
 * [개발 가이드](https://docs.buzzvil.com/)
 
 ### 오픈 소스 라이센스 고지
-- 이 소프트웨어가 사용하는 오픈 소스 소프트웨어의 라이센스는 "오픈 소스 라이센스 고지 페이지 ([원본 파일](docs/3rd_party_licenses.html)|[렌더링 버전](https://htmlpreview.github.io/?https://github.com/Buzzvil/buzz-sdk-samples/blob/master/3rd_party_licenses.html))"에서 확인할 수 있다.
+- 이 소프트웨어가 사용하는 오픈 소스 소프트웨어의 라이센스는 "오픈 소스 라이센스 고지 페이지 ([원본 파일](/3rd_party_licenses.html)|[렌더링 버전](https://htmlpreview.github.io/?https://github.com/Buzzvil/buzz-sdk-samples/blob/master/3rd_party_licenses.html))"에서 확인할 수 있다.
 
 ## [5.1.0] - 2023-11-30
 * [UPDATE] 인터스티셜 디자인 업데이트

--- a/buzzvil-sdk/README.md
+++ b/buzzvil-sdk/README.md
@@ -4,7 +4,7 @@
 * [개발 가이드](https://docs.buzzvil.com/docs/buzzbenefit-android/v5/getting-started)
 
 ### 오픈 소스 라이센스 고지
-- 이 소프트웨어가 사용하는 오픈 소스 소프트웨어의 라이센스는 "오픈 소스 라이센스 고지 페이지 ([원본 파일](/3rd_party_licenses.html)|[렌더링 버전](https://htmlpreview.github.io/?https://github.com/Buzzvil/buzzscreen-sdk-publisher/blob/master/docs/3rd_party_licenses.html))"에서 확인할 수 있다.
+- 이 소프트웨어가 사용하는 오픈 소스 소프트웨어의 라이센스는 "오픈 소스 라이센스 고지 페이지 ([원본 파일](/3rd_party_licenses.html)|[렌더링 버전](https://htmlpreview.github.io/?https://github.com/Buzzvil/buzz-sdk-samples/blob/master/3rd_party_licenses.html))"에서 확인할 수 있다.
 
 ## [5.1.0] - 2023-11-30
 * [UPDATE] 인터스티셜 지면의 디자인을 업데이트하여 닫기 버튼의 위치가 변경되었습니다.

--- a/buzzvil-sdk/README.md
+++ b/buzzvil-sdk/README.md
@@ -4,7 +4,7 @@
 * [개발 가이드](https://docs.buzzvil.com/docs/buzzbenefit-android/v5/getting-started)
 
 ### 오픈 소스 라이센스 고지
-- 이 소프트웨어가 사용하는 오픈 소스 소프트웨어의 라이센스는 "오픈 소스 라이센스 고지 페이지 ([원본 파일](docs/3rd_party_licenses.html)|[렌더링 버전](https://htmlpreview.github.io/?https://github.com/Buzzvil/buzzscreen-sdk-publisher/blob/master/docs/3rd_party_licenses.html))"에서 확인할 수 있다.
+- 이 소프트웨어가 사용하는 오픈 소스 소프트웨어의 라이센스는 "오픈 소스 라이센스 고지 페이지 ([원본 파일](/3rd_party_licenses.html)|[렌더링 버전](https://htmlpreview.github.io/?https://github.com/Buzzvil/buzzscreen-sdk-publisher/blob/master/docs/3rd_party_licenses.html))"에서 확인할 수 있다.
 
 ## [5.1.0] - 2023-11-30
 * [UPDATE] 인터스티셜 지면의 디자인을 업데이트하여 닫기 버튼의 위치가 변경되었습니다.


### PR DESCRIPTION
라이센스 정보를 제공하는 부분의 링크가 깨져있어서 수정했습니다.

- 원본 파일: 상대경로가 깨져있어서 절대경로로 변경했습니다.
- 랜더링 버전: 다른 리포지토리 파일이 링크 걸려있어서 수정했습니다.