### PR TITLE
BuzzvilSDK iOS 5.3.0

### DIFF
--- a/buzzvil-sdk-ios/Podfile
+++ b/buzzvil-sdk-ios/Podfile
@@ -8,7 +8,7 @@ target 'buzzvil-sdk-ios-swift' do
   use_frameworks!
   
   # Pods for buzzvil-sdk-ios
-  pod 'BuzzvilSDK', '= 5.2.0'
+  pod 'BuzzvilSDK', '= 5.3.0'
   
 end
 
@@ -16,7 +16,7 @@ target 'buzzvil-sdk-ios-objc' do
   use_frameworks!
   
   # Pods for buzzvil-sdk-ios-objc
-  pod 'BuzzvilSDK', '= 5.2.0'
+  pod 'BuzzvilSDK', '= 5.3.0'
   
 end
 

--- a/buzzvil-sdk-ios/Podfile
+++ b/buzzvil-sdk-ios/Podfile
@@ -8,7 +8,7 @@ target 'buzzvil-sdk-ios-swift' do
   use_frameworks!
   
   # Pods for buzzvil-sdk-ios
-  pod 'BuzzvilSDK', '= 5.3.0'
+  pod 'BuzzvilSDK', '= 5.3.1'
   
 end
 
@@ -16,7 +16,7 @@ target 'buzzvil-sdk-ios-objc' do
   use_frameworks!
   
   # Pods for buzzvil-sdk-ios-objc
-  pod 'BuzzvilSDK', '= 5.3.0'
+  pod 'BuzzvilSDK', '= 5.3.1'
   
 end
 

--- a/buzzvil-sdk-ios/Podfile.lock
+++ b/buzzvil-sdk-ios/Podfile.lock
@@ -14,19 +14,19 @@ PODS:
   - AFNetworking/Serialization (4.0.1)
   - AFNetworking/UIKit (4.0.1):
     - AFNetworking/NSURLSession
-  - BuzzAdBenefitSDK (5.2.0):
+  - BuzzAdBenefitSDK (5.3.0):
     - AFNetworking (~> 4.0)
     - BuzzRxSwift (~> 6.5.1)
     - GoogleAds-IMA-iOS-SDK (~> 3.12)
     - ReactiveObjC (~> 3.1.1)
     - SDWebImage (~> 5.0)
     - SDWebImageWebPCoder
-  - BuzzBoosterSDK (4.2.0):
+  - BuzzBoosterSDK (4.3.0):
     - BuzzRxSwift (~> 6.5.1)
   - BuzzRxSwift (6.5.1)
-  - BuzzvilSDK (5.2.0):
-    - BuzzAdBenefitSDK (~> 5.2.0)
-    - BuzzBoosterSDK (~> 4.2.0-rc.2)
+  - BuzzvilSDK (5.3.0):
+    - BuzzAdBenefitSDK (~> 5.3.0)
+    - BuzzBoosterSDK (~> 4.3.0)
     - BuzzRxSwift (~> 6.5.1)
   - GoogleAds-IMA-iOS-SDK (3.19.2)
   - libwebp (1.3.2):
@@ -50,15 +50,16 @@ PODS:
     - SDWebImage/Core (~> 5.17)
 
 DEPENDENCIES:
-  - BuzzvilSDK (= 5.2.0)
+  - BuzzvilSDK (= 5.3.0)
 
 SPEC REPOS:
+  https://github.com/Buzzvil/Specs.git:
+    - BuzzAdBenefitSDK
+    - BuzzvilSDK
   https://github.com/CocoaPods/Specs.git:
     - AFNetworking
-    - BuzzAdBenefitSDK
     - BuzzBoosterSDK
     - BuzzRxSwift
-    - BuzzvilSDK
     - GoogleAds-IMA-iOS-SDK
     - libwebp
     - ReactiveObjC
@@ -67,16 +68,16 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   AFNetworking: 3bd23d814e976cd148d7d44c3ab78017b744cd58
-  BuzzAdBenefitSDK: 2758b79c1cc51862edf79b63a630d52e24e13cad
-  BuzzBoosterSDK: f015117c42d451796764e1d3dff984abb4a07e34
+  BuzzAdBenefitSDK: 77b39e3b529791e09d9ad97d00522d74a1c9abf3
+  BuzzBoosterSDK: 231f87627ff732afba4818b59028e6de58846c3e
   BuzzRxSwift: 0ca1668aa41a0b4a811c9eb00d74c89a95a8553f
-  BuzzvilSDK: 87c0d6e2932a0cdba22f08b42d8c8261b068b02f
+  BuzzvilSDK: 7505bc4f5619994d5db4be44bd6c9edf7ec74668
   GoogleAds-IMA-iOS-SDK: 0e817c05ab26f1b9285c80f4a75e1350a916d50b
   libwebp: 1786c9f4ff8a279e4dac1e8f385004d5fc253009
   ReactiveObjC: 011caa393aa0383245f2dcf9bf02e86b80b36040
   SDWebImage: a81bbb3ba4ea5f810f4069c68727cb118467a04a
   SDWebImageWebPCoder: 633b813fca24f1de5e076bcd7f720c038b23892b
 
-PODFILE CHECKSUM: e47da79ec4e40e7b97884c30935369b057ac885b
+PODFILE CHECKSUM: ea59d1136010d53be6403d86b8cf4b11cfe68a9d
 
 COCOAPODS: 1.14.3

--- a/buzzvil-sdk-ios/Podfile.lock
+++ b/buzzvil-sdk-ios/Podfile.lock
@@ -14,7 +14,7 @@ PODS:
   - AFNetworking/Serialization (4.0.1)
   - AFNetworking/UIKit (4.0.1):
     - AFNetworking/NSURLSession
-  - BuzzAdBenefitSDK (5.3.0):
+  - BuzzAdBenefitSDK (5.3.1):
     - AFNetworking (~> 4.0)
     - BuzzRxSwift (~> 6.5.1)
     - GoogleAds-IMA-iOS-SDK (~> 3.12)
@@ -24,8 +24,8 @@ PODS:
   - BuzzBoosterSDK (4.3.0):
     - BuzzRxSwift (~> 6.5.1)
   - BuzzRxSwift (6.5.1)
-  - BuzzvilSDK (5.3.0):
-    - BuzzAdBenefitSDK (~> 5.3.0)
+  - BuzzvilSDK (5.3.1):
+    - BuzzAdBenefitSDK (~> 5.3.1)
     - BuzzBoosterSDK (~> 4.3.0)
     - BuzzRxSwift (~> 6.5.1)
   - GoogleAds-IMA-iOS-SDK (3.19.2)
@@ -42,24 +42,23 @@ PODS:
   - libwebp/webp (1.3.2):
     - libwebp/sharpyuv
   - ReactiveObjC (3.1.1)
-  - SDWebImage (5.18.8):
-    - SDWebImage/Core (= 5.18.8)
-  - SDWebImage/Core (5.18.8)
+  - SDWebImage (5.18.9):
+    - SDWebImage/Core (= 5.18.9)
+  - SDWebImage/Core (5.18.9)
   - SDWebImageWebPCoder (0.14.2):
     - libwebp (~> 1.0)
     - SDWebImage/Core (~> 5.17)
 
 DEPENDENCIES:
-  - BuzzvilSDK (= 5.3.0)
+  - BuzzvilSDK (= 5.3.1)
 
 SPEC REPOS:
-  https://github.com/Buzzvil/Specs.git:
-    - BuzzAdBenefitSDK
-    - BuzzvilSDK
   https://github.com/CocoaPods/Specs.git:
     - AFNetworking
+    - BuzzAdBenefitSDK
     - BuzzBoosterSDK
     - BuzzRxSwift
+    - BuzzvilSDK
     - GoogleAds-IMA-iOS-SDK
     - libwebp
     - ReactiveObjC
@@ -68,16 +67,16 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   AFNetworking: 3bd23d814e976cd148d7d44c3ab78017b744cd58
-  BuzzAdBenefitSDK: 77b39e3b529791e09d9ad97d00522d74a1c9abf3
+  BuzzAdBenefitSDK: 2ce5d16d1dcb94f3c8810a9c9315283688c8f297
   BuzzBoosterSDK: 231f87627ff732afba4818b59028e6de58846c3e
   BuzzRxSwift: 0ca1668aa41a0b4a811c9eb00d74c89a95a8553f
-  BuzzvilSDK: 7505bc4f5619994d5db4be44bd6c9edf7ec74668
+  BuzzvilSDK: 9d91400601528ff178be78030409bcd07e101abe
   GoogleAds-IMA-iOS-SDK: 0e817c05ab26f1b9285c80f4a75e1350a916d50b
   libwebp: 1786c9f4ff8a279e4dac1e8f385004d5fc253009
   ReactiveObjC: 011caa393aa0383245f2dcf9bf02e86b80b36040
-  SDWebImage: a81bbb3ba4ea5f810f4069c68727cb118467a04a
+  SDWebImage: 5e9b5f18ce88146692b1a5c174858948c84ff237
   SDWebImageWebPCoder: 633b813fca24f1de5e076bcd7f720c038b23892b
 
-PODFILE CHECKSUM: ea59d1136010d53be6403d86b8cf4b11cfe68a9d
+PODFILE CHECKSUM: 08602ba4386dfc38e88d9d19bf3fd4b635172fc2
 
 COCOAPODS: 1.14.3

--- a/buzzvil-sdk-ios/README.md
+++ b/buzzvil-sdk-ios/README.md
@@ -6,6 +6,12 @@
 ### 오픈 소스 라이센스 고지
 - 이 소프트웨어가 사용하는 오픈 소스 소프트웨어의 라이센스는 "오픈 소스 라이센스 고지 페이지 ([원본 파일](/3rd_party_licenses.html)|[렌더링 버전](https://htmlpreview.github.io/?https://github.com/Buzzvil/buzz-sdk-samples/blob/master/3rd_party_licenses.html))"에서 확인할 수 있다.
 
+## [5.3.0] - 2024-01-11
+* [FIX] 인터스티셜 지면에서 global theme이 적용되지 않는 문제 해결 
+* 자세한 사항은 [링크](https://docs.buzzvil.com/docs/release-news/ios/buzzvil5.3-buzzad3.45) 참조
+> ### [5.3.1] - 2024-01-11
+> * [FIX] BuzzBenefitMarketingStatus Objective-C 호환성 문제 해결
+
 ## [5.2.0] - 2023-12-28
 * [NEW] 자체 포인트 시스템이 없는 고객을 위한 리워드 시스템 출시
 * [FIX] 버그 수정

--- a/buzzvil-sdk-ios/buzzvil-sdk-ios-objc/AppDelegate.m
+++ b/buzzvil-sdk-ios/buzzvil-sdk-ios-objc/AppDelegate.m
@@ -52,6 +52,7 @@
     builder.userID = @"USER_ID";
     builder.gender = BuzzBenefitUserGenderMale;
     builder.birthYear = 1996;
+    builder.marketingStatus = BuzzBenefitMarketingStatusUndetermined; // (optional) BuzzBooster 이벤트 사용 시 필요한 옵션입니다. (BuzzBenefitMarketingStatusOptIn, BuzzBenefitMarketingStatusOptOut, BuzzBenefitMarketingStatusUndetermined)
   }];
   
   [[BuzzBenefit sharedInstance] loginWithUser:buzzBenefitUser onSuccess:^{

--- a/buzzvil-sdk-ios/buzzvil-sdk-ios-swift/AppDelegate.swift
+++ b/buzzvil-sdk-ios/buzzvil-sdk-ios-swift/AppDelegate.swift
@@ -45,6 +45,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     let buzzBenefitUser = BuzzBenefitUser.Builder(userID: "USER_ID")
       .setGender(.male)
       .setBirthYear(1996)
+      .setMarketingStatus(.undetermined) // (optional) BuzzBooster 이벤트 사용 시 필요한 옵션 입니다. (.optIn/.optOut /.undetermined )
       .build()
     
     BuzzBenefit.shared.login(


### PR DESCRIPTION
reviewer : @Gongcu 

BuzzBenefit SDK 버전을 5.3.0 으로 올립니다.
새롭게 추가된 BuzzBenefitUser.marketingStatus 관련 코드가 추가되었습니다.

BuzzBenefit 5.3.0 public 배포 이후에 pod install 이 필요합니다.