### PR TITLE
[OUTPUT-3029] 샘플앱에서 Load Carousel을 여러 번 하면 아이템 크기가 계속 작아지는 문제 해결

### DIFF
--- a/buzzvil-sdk-android/app/src/main/java/com/buzzvil/sample/buzzvilsdksample/nativead/NativeCarouselActivity.kt
+++ b/buzzvil-sdk-android/app/src/main/java/com/buzzvil/sample/buzzvilsdksample/nativead/NativeCarouselActivity.kt
@@ -24,6 +24,9 @@ class NativeCarouselActivity : AppCompatActivity() {
         binding = ActivityNativeCarouselBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
+        // 캐러셀 아이템 각각에 양 옆 여백 설정
+        binding.carouselRecyclerView.addItemDecoration(PaddingDividerDecoration(16))
+
         binding.loadCarouselButton.setOnClickListener {
             initCarouselPool()
         }
@@ -62,9 +65,6 @@ class NativeCarouselActivity : AppCompatActivity() {
 
         // RecyclerView에 어댑터를 설정합니다.
         binding.carouselRecyclerView.adapter = adapter
-
-        // 양 옆 여백 설정
-        binding.carouselRecyclerView.addItemDecoration(PaddingDividerDecoration(16))
 
         if (isInfiniteLoopEnabled) {
             // 적당히 큰 수의 position으로 이동하여 무한 스크롤 효과를 구현합니다.


### PR DESCRIPTION
addItemDecoration을 한 번만 하도록 위치를 옮깁니다.

https://github.com/Buzzvil/buzz-android/pull/3581 와 동일한 작업입니다.