### PR TITLE
[FIX] BuzzvilSDK iOS 메인화면의 Banner Layout 을 수정합니다.

### DIFF
--- a/buzzvil-sdk-ios/buzzvil-sdk-ios-swift/ViewController.swift
+++ b/buzzvil-sdk-ios/buzzvil-sdk-ios-swift/ViewController.swift
@@ -138,10 +138,10 @@ class ViewController: UIViewController {
     
     bannerButton.translatesAutoresizingMaskIntoConstraints = false
     NSLayoutConstraint.activate([
-      feedButton.topAnchor.constraint(equalTo: feedButton.bottomAnchor, constant: Self.buttonMargin),
-      feedButton.leadingAnchor.constraint(equalTo: view.centerXAnchor, constant: Self.buttonMargin/2),
-      feedButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -Self.buttonMargin),
-      feedButton.widthAnchor.constraint(equalTo: bannerButton.heightAnchor, multiplier: Self.buttonAspectRatio)
+      bannerButton.topAnchor.constraint(equalTo: feedButton.bottomAnchor, constant: Self.buttonMargin),
+      bannerButton.leadingAnchor.constraint(equalTo: view.centerXAnchor, constant: Self.buttonMargin/2),
+      bannerButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -Self.buttonMargin),
+      bannerButton.widthAnchor.constraint(equalTo: bannerButton.heightAnchor, multiplier: Self.buttonAspectRatio)
     ])
   }
   


### PR DESCRIPTION
메인화면의  Banner 버튼의 레이아웃이 잘못 구현되어 있어서 위치를 의도한곳으로 옮깁니다.