### PR TITLE
feat:add flexad sample

### DIFF
--- a/buzzvil-sdk-v6-android/app/build.gradle.kts
+++ b/buzzvil-sdk-v6-android/app/build.gradle.kts
@@ -40,7 +40,7 @@ android {
 
 dependencies {
     // buzzvil-sdk
-    val buzzvilBomVersion = "6.4.5"
+    val buzzvilBomVersion = "6.7.2"
 
     api(platform("com.buzzvil:buzzvil-bom:$buzzvilBomVersion"))
     implementation("com.buzzvil:buzzvil-sdk")

--- a/buzzvil-sdk-v6-android/app/src/main/AndroidManifest.xml
+++ b/buzzvil-sdk-v6-android/app/src/main/AndroidManifest.xml
@@ -40,6 +40,9 @@
         <activity
             android:name=".banner.YourBannerActivity"
             android:exported="false" />
+        <activity
+            android:name=".flexad.YourFlexAdActivity"
+            android:exported="false" />
 
         <service
             android:name=".pop.YourBuzzPopControlService"

--- a/buzzvil-sdk-v6-android/app/src/main/java/com/buzzvil/sample/buzzvil_sdk_v6_sample/Constant.kt
+++ b/buzzvil-sdk-v6-android/app/src/main/java/com/buzzvil/sample/buzzvil_sdk_v6_sample/Constant.kt
@@ -11,4 +11,5 @@ object Constant {
     const val YOUR_NATIVE_ID = "YOUR_NATIVE_ID"
     const val YOUR_INTERSTITIAL_ID = "YOUR_INTERSTITIAL_ID"
     const val YOUR_BANNER_ID = "YOUR_BANNER_ID"
+    const val YOUR_FLEX_AD_ID = "YOUR_FLEX_AD_ID"
 }

--- a/buzzvil-sdk-v6-android/app/src/main/java/com/buzzvil/sample/buzzvil_sdk_v6_sample/MainActivity.kt
+++ b/buzzvil-sdk-v6-android/app/src/main/java/com/buzzvil/sample/buzzvil_sdk_v6_sample/MainActivity.kt
@@ -14,6 +14,7 @@ import com.buzzvil.buzzbenefit.pop.BuzzPop
 import com.buzzvil.buzzbenefit.pop.BuzzPopActivateListener
 import com.buzzvil.sample.buzzvil_sdk_v6_sample.Constant.YOUR_USER_ID
 import com.buzzvil.sample.buzzvil_sdk_v6_sample.banner.YourBannerActivity
+import com.buzzvil.sample.buzzvil_sdk_v6_sample.flexad.YourFlexAdActivity
 import com.buzzvil.sample.buzzvil_sdk_v6_sample.buzzbenefithub.YourBenefitHubActivity
 import com.buzzvil.sample.buzzvil_sdk_v6_sample.buzzentrypoint.BuzzEntryPointActivity
 import com.buzzvil.sample.buzzvil_sdk_v6_sample.buzznative.YourNativeCarouselActivity
@@ -212,6 +213,11 @@ class MainActivity : AppCompatActivity() {
         // Banner
         binding.buzzBannerButton.setOnClickListener {
             navigateActivity(YourBannerActivity::class.java)
+        }
+
+        // FlexAd
+        binding.flexAdButton.setOnClickListener {
+            navigateActivity(YourFlexAdActivity::class.java)
         }
 
 

--- a/buzzvil-sdk-v6-android/app/src/main/java/com/buzzvil/sample/buzzvil_sdk_v6_sample/flexad/YourFlexAdActivity.kt
+++ b/buzzvil-sdk-v6-android/app/src/main/java/com/buzzvil/sample/buzzvil_sdk_v6_sample/flexad/YourFlexAdActivity.kt
@@ -1,0 +1,48 @@
+package com.buzzvil.sample.buzzvil_sdk_v6_sample.flexad
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.buzzvil.buzzbenefit.BuzzAdError
+import com.buzzvil.buzzbenefit.flexad.BuzzFlex
+import com.buzzvil.buzzbenefit.flexad.BuzzFlexAdView
+import com.buzzvil.sample.buzzvil_sdk_v6_sample.Constant
+import com.buzzvil.sample.buzzvil_sdk_v6_sample.databinding.ActivityYourFlexAdBinding
+
+class YourFlexAdActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityYourFlexAdBinding
+    private lateinit var buzzFlex: BuzzFlex
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityYourFlexAdBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        val buzzFlexAdView = BuzzFlexAdView(this)
+        binding.buzzFlexAdContainer.addView(buzzFlexAdView)
+
+        buzzFlex = BuzzFlex(Constant.YOUR_FLEX_AD_ID)
+        buzzFlex.setListener(object : BuzzFlex.Listener {
+            override fun onSuccess() {
+                // 광고 로드 성공 시 호출됩니다.
+                // BuzzFlexAdView에 광고를 표시합니다.
+                buzzFlexAdView.bind(buzzFlex)
+            }
+
+            override fun onFailure(adError: BuzzAdError) {
+                // 광고 로드 실패 시 호출됩니다.
+            }
+
+            override fun onClicked() {
+                // 광고 클릭 시 호출됩니다.
+            }
+        })
+
+        buzzFlex.load()
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        buzzFlex.dispose()
+    }
+}

--- a/buzzvil-sdk-v6-android/app/src/main/res/layout/activity_main.xml
+++ b/buzzvil-sdk-v6-android/app/src/main/res/layout/activity_main.xml
@@ -226,6 +226,21 @@
                 android:layout_marginHorizontal="16dp"
                 android:text="BuzzBanner" />
 
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="16dp"
+                android:layout_marginTop="16dp"
+                android:text="FlexAd"
+                android:textSize="24dp" />
+
+            <Button
+                android:id="@+id/flexAdButton"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="16dp"
+                android:text="FlexAd" />
+
         </LinearLayout>
     </ScrollView>
 </FrameLayout>

--- a/buzzvil-sdk-v6-android/app/src/main/res/layout/activity_your_flex_ad.xml
+++ b/buzzvil-sdk-v6-android/app/src/main/res/layout/activity_your_flex_ad.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <FrameLayout
+        android:id="@+id/buzzFlexAdContainer"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+</LinearLayout>

--- a/buzzvil-sdk-v6-ios/Podfile
+++ b/buzzvil-sdk-v6-ios/Podfile
@@ -7,19 +7,19 @@ platform :ios, deployment_target
 target 'buzzvil-sdk-ios-objc' do
   use_frameworks!
   
-  pod 'BuzzvilSDK', '= 6.4.3'
+  pod 'BuzzvilSDK', '= 6.7.1'
 end
 
 target 'buzzvil-sdk-ios-swift' do
   use_frameworks!
-  
-  pod 'BuzzvilSDK', '= 6.4.3'
+
+  pod 'BuzzvilSDK', '= 6.7.1'
 end
 
 target 'buzzvil-sdk-ios-swiftui' do
   use_frameworks!
-  
-  pod 'BuzzvilSDK', '= 6.4.3'
+
+  pod 'BuzzvilSDK', '= 6.7.1'
 end
 
 post_install do |installer|

--- a/buzzvil-sdk-v6-ios/buzzvil-sdk-ios-swift/FlexAd/FlexAdViewController.swift
+++ b/buzzvil-sdk-v6-ios/buzzvil-sdk-ios-swift/FlexAd/FlexAdViewController.swift
@@ -1,0 +1,52 @@
+import UIKit
+import BuzzvilSDK
+
+class FlexAdViewController: UIViewController {
+
+    private let buzzFlex = BuzzFlex(unitId: "YOUR_FLEX_AD_UNIT_ID")
+
+    private lazy var flexAdView: BuzzFlexAdView = {
+        let view = BuzzFlexAdView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .systemBackground
+        navigationItem.title = "FlexAd"
+
+        setupLayout()
+        loadAd()
+    }
+
+    private func setupLayout() {
+        view.addSubview(flexAdView)
+        NSLayoutConstraint.activate([
+            flexAdView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 16),
+            flexAdView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            flexAdView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+        ])
+    }
+
+    private func loadAd() {
+        buzzFlex.delegate = self
+        buzzFlex.load()
+    }
+}
+
+extension FlexAdViewController: BuzzFlexDelegate {
+    func buzzFlexOnSuccess() {
+        // 광고 로드 성공 시 호출됩니다.
+        // BuzzFlexAdView에 광고를 표시합니다.
+        flexAdView.bind(buzzFlex)
+    }
+
+    func buzzFlexOnFailure(_ error: Error) {
+        // 광고 로드 실패 시 호출됩니다.
+    }
+
+    func buzzFlexOnClicked() {
+        // 광고 클릭 시 호출됩니다.
+    }
+}

--- a/buzzvil-sdk-v6-ios/buzzvil-sdk-ios-swift/ViewController.swift
+++ b/buzzvil-sdk-v6-ios/buzzvil-sdk-ios-swift/ViewController.swift
@@ -65,6 +65,13 @@ class ViewController: UIViewController {
     button.addTarget(self, action: #selector(pushEntryPointViewController), for: .touchUpInside)
     return button
   }()
+
+  private lazy var flexAdButton: UIButton = {
+    let button = UIButton(frame: .zero)
+    button.setTitle("FlexAd", for: .normal)
+    button.addTarget(self, action: #selector(pushFlexAdViewController), for: .touchUpInside)
+    return button
+  }()
   
   private lazy var inquiryButton: UIButton = {
     let button = UIButton(frame: .zero)
@@ -117,6 +124,7 @@ class ViewController: UIViewController {
     rootStackView.addArrangedSubview(benefitHubCustomNaviContainerButton)
     rootStackView.addArrangedSubview(bannerButton)
     rootStackView.addArrangedSubview(entryPointButton)
+    rootStackView.addArrangedSubview(flexAdButton)
     rootStackView.addArrangedSubview(inquiryButton)
     rootStackView.addArrangedSubview(privacyConsentStatusLabel)
     rootStackView.addArrangedSubview(loadPrivacyConsentStatusButton)
@@ -133,6 +141,7 @@ class ViewController: UIViewController {
       benefitHubCustomNaviContainerButton,
       bannerButton,
       entryPointButton,
+      flexAdButton,
       inquiryButton,
       loadPrivacyConsentStatusButton,
       grantPrivacyConsentButton,
@@ -202,6 +211,11 @@ class ViewController: UIViewController {
   @objc private func pushEntryPointViewController() {
     let entryPointViewController = EntryPointViewController()
     navigationController?.pushViewController(entryPointViewController, animated: true)
+  }
+
+  @objc private func pushFlexAdViewController() {
+    let flexAdViewController = FlexAdViewController()
+    navigationController?.pushViewController(flexAdViewController, animated: true)
   }
   
   @objc private func showInquiry() {


### PR DESCRIPTION
add flexad sample

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds FlexAd sample screens for Android and iOS to demonstrate loading and rendering with `BuzzFlex`. Also updates SDKs to the 6.7.x line.

- **New Features**
  - Android: Added `YourFlexAdActivity` using `BuzzFlex` + `BuzzFlexAdView`; added `YOUR_FLEX_AD_ID`, manifest entry, and a "FlexAd" button in `MainActivity`.
  - iOS: Added `FlexAdViewController` using `BuzzFlex` + `BuzzFlexAdView`; added a "FlexAd" button in `ViewController`.

- **Dependencies**
  - Android: Updated `com.buzzvil:buzzvil-bom` to `6.7.2`.
  - iOS: Updated `BuzzvilSDK` CocoaPod to `6.7.1`.

<sup>Written for commit 8735983e4540e362219534ad5a688dda9f52971c. Summary will update on new commits. <a href="https://cubic.dev/pr/Buzzvil/buzz-sdk-samples/pull/271?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

