### PR TITLE
Update Buzzvil SDK (iOS 6.7.7 / Android 6.7.9)

### DIFF
--- a/buzzvil-sdk-v6-android/app/build.gradle.kts
+++ b/buzzvil-sdk-v6-android/app/build.gradle.kts
@@ -40,7 +40,7 @@ android {
 
 dependencies {
     // buzzvil-sdk
-    val buzzvilBomVersion = "6.7.2"
+    val buzzvilBomVersion = "6.7.9"
 
     api(platform("com.buzzvil:buzzvil-bom:$buzzvilBomVersion"))
     implementation("com.buzzvil:buzzvil-sdk")

--- a/buzzvil-sdk-v6-ios/Podfile
+++ b/buzzvil-sdk-v6-ios/Podfile
@@ -7,19 +7,19 @@ platform :ios, deployment_target
 target 'buzzvil-sdk-ios-objc' do
   use_frameworks!
   
-  pod 'BuzzvilSDK', '= 6.7.1'
+  pod 'BuzzvilSDK', '= 6.7.7'
 end
 
 target 'buzzvil-sdk-ios-swift' do
   use_frameworks!
 
-  pod 'BuzzvilSDK', '= 6.7.1'
+  pod 'BuzzvilSDK', '= 6.7.7'
 end
 
 target 'buzzvil-sdk-ios-swiftui' do
   use_frameworks!
 
-  pod 'BuzzvilSDK', '= 6.7.1'
+  pod 'BuzzvilSDK', '= 6.7.7'
 end
 
 post_install do |installer|

--- a/buzzvil-sdk-v6-ios/Podfile.lock
+++ b/buzzvil-sdk-v6-ios/Podfile.lock
@@ -1,30 +1,20 @@
 PODS:
-  - AdPopcornSSP (2.10.7)
-  - AvatyeAdCash (3.3.4):
-    - AdPopcornSSP (~> 2.10.5)
-  - BuzzAdBenefitSDK (6.4.3):
-    - BuzzRxSwift (= 7.0.0)
-    - GoogleAds-IMA-iOS-SDK (~> 3.23)
-  - BuzzAvatyeAdCash (6.4.3):
-    - AvatyeAdCash (~> 3.3.2)
-    - BuzzAdBenefitSDK (= 6.4.3)
-  - BuzzBoosterSDK (6.4.3):
-    - BuzzRxSwift (= 7.0.0)
-  - BuzzRxSwift (7.0.0)
-  - BuzzvilSDK (6.4.3):
-    - BuzzAdBenefitSDK (= 6.4.3)
-    - BuzzBoosterSDK (= 6.4.3)
-    - BuzzRxSwift (= 7.0.0)
-    - BuzzvilSDK/Default (= 6.4.3)
-  - BuzzvilSDK/Default (6.4.3):
-    - BuzzAdBenefitSDK (= 6.4.3)
-    - BuzzAvatyeAdCash (= 6.4.3)
-    - BuzzBoosterSDK (= 6.4.3)
-    - BuzzRxSwift (= 7.0.0)
-  - GoogleAds-IMA-iOS-SDK (3.27.4)
+  - AdPopcornSSP (2.11.9)
+  - AvatyeAdCash (3.4.2):
+    - AdPopcornSSP (~> 2.11.1)
+  - BuzzAdBenefitSDK (6.7.7)
+  - BuzzAvatyeAdCash (6.7.7):
+    - AvatyeAdCash (~> 3.4.2)
+    - BuzzAdBenefitSDK (= 6.7.7)
+  - BuzzvilSDK (6.7.7):
+    - BuzzAdBenefitSDK (= 6.7.7)
+    - BuzzvilSDK/Default (= 6.7.7)
+  - BuzzvilSDK/Default (6.7.7):
+    - BuzzAdBenefitSDK (= 6.7.7)
+    - BuzzAvatyeAdCash (= 6.7.7)
 
 DEPENDENCIES:
-  - BuzzvilSDK (= 6.4.3)
+  - BuzzvilSDK (= 6.7.7)
 
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
@@ -32,21 +22,15 @@ SPEC REPOS:
     - AvatyeAdCash
     - BuzzAdBenefitSDK
     - BuzzAvatyeAdCash
-    - BuzzBoosterSDK
-    - BuzzRxSwift
     - BuzzvilSDK
-    - GoogleAds-IMA-iOS-SDK
 
 SPEC CHECKSUMS:
-  AdPopcornSSP: 8488e28a8c76bd0fbea5447a94c1d713309c5c5d
-  AvatyeAdCash: 2b8b87cd86240658dd78ad847a8562f58596e975
-  BuzzAdBenefitSDK: f711bec0683ef9cd5cfc1c39d0d66fed0fceb834
-  BuzzAvatyeAdCash: b999b989b7bc738e2945001ba138ad76c7434266
-  BuzzBoosterSDK: 799c3cb3c8a38d51f7a85edac1430d901756267b
-  BuzzRxSwift: 8d04c2083985af36f1e28a9a4db45675c6816c34
-  BuzzvilSDK: 796ef046454ab0fbfa6da806a9e7886c086ea000
-  GoogleAds-IMA-iOS-SDK: 1c696013d47bc3cafa48b7de9c8196941bd3105b
+  AdPopcornSSP: aca347b5f575b3e7d06b76b18be43251d3f21e30
+  AvatyeAdCash: feee179adf2811beb35e0917d8eef6efd59b08a6
+  BuzzAdBenefitSDK: 65e902c157984ceeaea00d7d62f27a117bfa3037
+  BuzzAvatyeAdCash: b593259acd92e7a72786cba0db761d9fa8eadb69
+  BuzzvilSDK: 014220a103c6bc5de0fbe6cd0108c07efccd9849
 
-PODFILE CHECKSUM: f83c19c865a035cdca35b1adbd815422c18c3694
+PODFILE CHECKSUM: 6a7194bdb661fb4a00a6e9e09933e655d72f21ef
 
 COCOAPODS: 1.16.2

--- a/buzzvil-sdk-v6-ios/buzzvil-sdk-ios-v6.xcodeproj/project.pbxproj
+++ b/buzzvil-sdk-v6-ios/buzzvil-sdk-ios-v6.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		008FB3732D8909F400DA135E /* CustomCtaView.m in Sources */ = {isa = PBXBuildFile; fileRef = 008FB3432D8909F400DA135E /* CustomCtaView.m */; };
 		008FB3752D8909F400DA135E /* BenefitHubContainerViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 008FB3642D8909F400DA135E /* BenefitHubContainerViewController.m */; };
 		008FB3762D8909F400DA135E /* UIButton+Custom.m in Sources */ = {isa = PBXBuildFile; fileRef = 008FB3402D8909F400DA135E /* UIButton+Custom.m */; };
+		45B7DF90249E277C9C58C0A3 /* FlexAdViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6D40A31A9D7AC52F9DFEE9 /* FlexAdViewController.swift */; };
 		6520320D2E20F92500B1B227 /* EntryPointViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 6520320C2E20F92500B1B227 /* EntryPointViewController.m */; };
 		652032102E20FD7500B1B227 /* EntryPointView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6520320F2E20FD7500B1B227 /* EntryPointView.swift */; };
 		654651552DAE406700684E6F /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 654651522DAE406700684E6F /* ContentView.swift */; };
@@ -122,6 +123,7 @@
 		65BB66F32DB22AEC000D1381 /* CustomCtaView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomCtaView.swift; sourceTree = "<group>"; };
 		65BB66F62DB22B3D000D1381 /* BannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerView.swift; sourceTree = "<group>"; };
 		65BB66F92DB22FD5000D1381 /* PrivacyConsentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyConsentView.swift; sourceTree = "<group>"; };
+		8A6D40A31A9D7AC52F9DFEE9 /* FlexAdViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FlexAdViewController.swift; sourceTree = "<group>"; };
 		9DF2B4AF44BEA0294F33A1FA /* Pods_buzzvil_sdk_ios_objc.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_buzzvil_sdk_ios_objc.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A6C9481B4C732CB7679FBAD3 /* Pods-buzzvil-sdk-ios-v6.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-buzzvil-sdk-ios-v6.debug.xcconfig"; path = "Target Support Files/Pods-buzzvil-sdk-ios-v6/Pods-buzzvil-sdk-ios-v6.debug.xcconfig"; sourceTree = "<group>"; };
 		C0CD1C640147ADD6CAF2754C /* Pods_buzzvil_sdk_ios_swift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_buzzvil_sdk_ios_swift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -194,6 +196,7 @@
 				0041F4C72D87E7E300B901E2 /* Info.plist */,
 				0041F4CC2D87E7E300B901E2 /* SceneDelegate.swift */,
 				0041F4CD2D87E7E300B901E2 /* ViewController.swift */,
+				656F52F73CBF16653CDDE181 /* FlexAd */,
 			);
 			path = "buzzvil-sdk-ios-swift";
 			sourceTree = "<group>";
@@ -427,6 +430,15 @@
 				65577C882E03F2300019DAE8 /* EntryPointViewController.swift */,
 			);
 			path = EntryPoint;
+			sourceTree = "<group>";
+		};
+		656F52F73CBF16653CDDE181 /* FlexAd */ = {
+			isa = PBXGroup;
+			children = (
+				8A6D40A31A9D7AC52F9DFEE9 /* FlexAdViewController.swift */,
+			);
+			name = FlexAd;
+			path = FlexAd;
 			sourceTree = "<group>";
 		};
 		65BB66F22DB22AD3000D1381 /* Custom */ = {
@@ -789,6 +801,7 @@
 				0041F52F2D87EE7C00B901E2 /* NativeViewController.swift in Sources */,
 				0041F5302D87EE7C00B901E2 /* BenefitHubContainerViewController.swift in Sources */,
 				0041F5312D87EE7C00B901E2 /* CarouselViewController.swift in Sources */,
+				45B7DF90249E277C9C58C0A3 /* FlexAdViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
샘플앱 Buzzvil SDK 버전 업데이트 및 FlexAd 예제 프로젝트 참조 누락 수정

- iOS: BuzzvilSDK 6.7.1 → 6.7.7
- Android: buzzvil-bom 6.7.2 → 6.7.9
- iOS(fix): FlexAdViewController.swift가 Xcode 프로젝트에 미포함되어 있던 문제 수정