### PR TITLE
Update Buzzvil SDK (iOS 6.7.9 / Android 6.7.10)

### DIFF
--- a/buzzvil-sdk-v6-android/app/build.gradle.kts
+++ b/buzzvil-sdk-v6-android/app/build.gradle.kts
@@ -40,7 +40,7 @@ android {
 
 dependencies {
     // buzzvil-sdk
-    val buzzvilBomVersion = "6.7.9"
+    val buzzvilBomVersion = "6.7.10"
 
     api(platform("com.buzzvil:buzzvil-bom:$buzzvilBomVersion"))
     implementation("com.buzzvil:buzzvil-sdk")

--- a/buzzvil-sdk-v6-android/app/src/main/java/com/buzzvil/sample/buzzvil_sdk_v6_sample/flexad/YourFlexAdActivity.kt
+++ b/buzzvil-sdk-v6-android/app/src/main/java/com/buzzvil/sample/buzzvil_sdk_v6_sample/flexad/YourFlexAdActivity.kt
@@ -1,13 +1,27 @@
 package com.buzzvil.sample.buzzvil_sdk_v6_sample.flexad
 
+import android.graphics.Color
+import android.graphics.Typeface
+import android.graphics.drawable.GradientDrawable
 import android.os.Bundle
+import android.util.TypedValue
+import android.view.Gravity
+import android.view.View
+import android.widget.ImageView
+import android.widget.LinearLayout
+import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.graphics.ColorUtils
 import com.buzzvil.buzzbenefit.BuzzAdError
 import com.buzzvil.buzzbenefit.flexad.BuzzFlex
 import com.buzzvil.buzzbenefit.flexad.BuzzFlexAdView
 import com.buzzvil.sample.buzzvil_sdk_v6_sample.Constant
+import com.buzzvil.sample.buzzvil_sdk_v6_sample.R
 import com.buzzvil.sample.buzzvil_sdk_v6_sample.databinding.ActivityYourFlexAdBinding
 
+/**
+ * FlexAd를 스크롤 피드 최상단에 배치해, 스크롤 인/아웃에 따른 뷰어빌리티 동작을 확인하는 예시 화면.
+ */
 class YourFlexAdActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivityYourFlexAdBinding
@@ -15,34 +29,137 @@ class YourFlexAdActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        title = "FlexAd"
         binding = ActivityYourFlexAdBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
         val buzzFlexAdView = BuzzFlexAdView(this)
         binding.buzzFlexAdContainer.addView(buzzFlexAdView)
 
+        setupSampleContent()
+
         buzzFlex = BuzzFlex(Constant.YOUR_FLEX_AD_ID)
         buzzFlex.setListener(object : BuzzFlex.Listener {
             override fun onSuccess() {
-                // 광고 로드 성공 시 호출됩니다.
-                // BuzzFlexAdView에 광고를 표시합니다.
                 buzzFlexAdView.bind(buzzFlex)
             }
 
-            override fun onFailure(adError: BuzzAdError) {
-                // 광고 로드 실패 시 호출됩니다.
-            }
+            override fun onFailure(adError: BuzzAdError) {}
 
-            override fun onClicked() {
-                // 광고 클릭 시 호출됩니다.
-            }
+            override fun onClicked() {}
         })
-
         buzzFlex.load()
     }
 
     override fun onDestroy() {
         super.onDestroy()
         buzzFlex.dispose()
+    }
+
+    // MARK: - 예시용 샘플 콘텐츠
+
+    private data class SampleItem(val title: String, val body: String)
+
+    private fun setupSampleContent() {
+        binding.contentContainer.addView(makeSampleNotice())
+        sampleFeed.forEachIndexed { index, item ->
+            binding.contentContainer.addView(makeSampleCard(item, thumbnailTints[index % thumbnailTints.size]))
+        }
+    }
+
+    private fun makeSampleNotice(): View =
+        TextView(this).apply {
+            text = "· 아래는 스크롤 예시용 샘플 콘텐츠입니다. ·"
+            setTextColor(Color.parseColor("#9E9E9E"))
+            textSize = 12f
+            gravity = Gravity.CENTER
+            layoutParams = LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT,
+                LinearLayout.LayoutParams.WRAP_CONTENT,
+            ).apply { setMargins(dp(16), dp(16), dp(16), dp(8)) }
+        }
+
+    private fun makeSampleCard(item: SampleItem, tint: Int): View {
+        val row = LinearLayout(this).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.CENTER_VERTICAL
+            layoutParams = LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT,
+                LinearLayout.LayoutParams.WRAP_CONTENT,
+            ).apply { setMargins(dp(16), dp(8), dp(16), dp(8)) }
+        }
+
+        val thumbnail = ImageView(this).apply {
+            setImageResource(R.drawable.ic_sample_image)
+            setColorFilter(tint)
+            scaleType = ImageView.ScaleType.CENTER_INSIDE
+            setPadding(dp(20), dp(20), dp(20), dp(20))
+            background = GradientDrawable().apply {
+                cornerRadius = dp(8).toFloat()
+                setColor(ColorUtils.setAlphaComponent(tint, 38))
+            }
+            layoutParams = LinearLayout.LayoutParams(dp(72), dp(72))
+        }
+        row.addView(thumbnail)
+
+        val textColumn = LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            layoutParams = LinearLayout.LayoutParams(
+                0,
+                LinearLayout.LayoutParams.WRAP_CONTENT,
+                1f,
+            ).apply { marginStart = dp(12) }
+        }
+        textColumn.addView(TextView(this).apply {
+            text = item.title
+            setTextColor(Color.parseColor("#1C1C1E"))
+            textSize = 15f
+            setTypeface(typeface, Typeface.BOLD)
+            maxLines = 2
+        })
+        textColumn.addView(TextView(this).apply {
+            text = item.body
+            setTextColor(Color.parseColor("#6E6E73"))
+            textSize = 13f
+            maxLines = 2
+        })
+        textColumn.addView(TextView(this).apply {
+            text = "예시"
+            setTextColor(Color.parseColor("#AEAEB2"))
+            textSize = 10f
+            setTypeface(typeface, Typeface.BOLD)
+        })
+        row.addView(textColumn)
+
+        return row
+    }
+
+    private fun dp(value: Int): Int =
+        TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, value.toFloat(), resources.displayMetrics).toInt()
+
+    private companion object {
+        val thumbnailTints = intArrayOf(
+            Color.parseColor("#007AFF"),
+            Color.parseColor("#34C759"),
+            Color.parseColor("#FF9500"),
+            Color.parseColor("#AF52DE"),
+            Color.parseColor("#FF2D55"),
+            Color.parseColor("#30B0C7"),
+        )
+
+        val sampleFeed = listOf(
+            SampleItem("샘플 콘텐츠 · 오늘의 주요 소식", "스크롤 확인용 예시 콘텐츠입니다."),
+            SampleItem("샘플 콘텐츠 · 이번 주 인기 글", "실제 서비스 데이터가 아닌 자리표시자입니다."),
+            SampleItem("샘플 콘텐츠 · 라이프스타일 팁", "레이아웃 미리보기를 위한 목업 텍스트입니다."),
+            SampleItem("샘플 콘텐츠 · 테크 브리핑", "예시용으로 채워 넣은 내용입니다."),
+            SampleItem("샘플 콘텐츠 · 건강 상식", "스크롤 공간 확보를 위한 샘플입니다."),
+            SampleItem("샘플 콘텐츠 · 여행 가이드", "실제 콘텐츠가 아닌 예시 텍스트입니다."),
+            SampleItem("샘플 콘텐츠 · 오늘의 맛집", "자리표시자 예시 콘텐츠입니다."),
+            SampleItem("샘플 콘텐츠 · 경제 브리핑", "미리보기용 목업 문구입니다."),
+            SampleItem("샘플 콘텐츠 · 문화·이벤트", "실제 서비스 데이터가 아닙니다."),
+            SampleItem("샘플 콘텐츠 · 스포츠 하이라이트", "스크롤 확인용 예시 콘텐츠입니다."),
+            SampleItem("샘플 콘텐츠 · 날씨 브리핑", "레이아웃 예시를 위한 자리표시자입니다."),
+            SampleItem("샘플 콘텐츠 · 추천 읽을거리", "예시용으로 채워 넣은 목업 텍스트입니다."),
+        )
     }
 }

--- a/buzzvil-sdk-v6-android/app/src/main/res/drawable/ic_sample_image.xml
+++ b/buzzvil-sdk-v6-android/app/src/main/res/drawable/ic_sample_image.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M21,19V5c0,-1.1 -0.9,-2 -2,-2H5c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2zM8.5,13.5l2.5,3.01L14.5,12l4.5,6H5l3.5,-4.5z" />
+</vector>

--- a/buzzvil-sdk-v6-android/app/src/main/res/layout/activity_your_flex_ad.xml
+++ b/buzzvil-sdk-v6-android/app/src/main/res/layout/activity_your_flex_ad.xml
@@ -1,13 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:padding="16dp">
+    android:layout_height="match_parent">
 
-    <FrameLayout
-        android:id="@+id/buzzFlexAdContainer"
+    <LinearLayout
+        android:id="@+id/contentContainer"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingTop="16dp"
+        android:paddingBottom="16dp">
 
-</LinearLayout>
+        <FrameLayout
+            android:id="@+id/buzzFlexAdContainer"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp" />
+
+    </LinearLayout>
+</ScrollView>

--- a/buzzvil-sdk-v6-ios/Podfile
+++ b/buzzvil-sdk-v6-ios/Podfile
@@ -7,19 +7,19 @@ platform :ios, deployment_target
 target 'buzzvil-sdk-ios-objc' do
   use_frameworks!
   
-  pod 'BuzzvilSDK', '= 6.7.7'
+  pod 'BuzzvilSDK', '= 6.7.9'
 end
 
 target 'buzzvil-sdk-ios-swift' do
   use_frameworks!
 
-  pod 'BuzzvilSDK', '= 6.7.7'
+  pod 'BuzzvilSDK', '= 6.7.9'
 end
 
 target 'buzzvil-sdk-ios-swiftui' do
   use_frameworks!
 
-  pod 'BuzzvilSDK', '= 6.7.7'
+  pod 'BuzzvilSDK', '= 6.7.9'
 end
 
 post_install do |installer|

--- a/buzzvil-sdk-v6-ios/Podfile.lock
+++ b/buzzvil-sdk-v6-ios/Podfile.lock
@@ -2,19 +2,19 @@ PODS:
   - AdPopcornSSP (2.11.9)
   - AvatyeAdCash (3.4.2):
     - AdPopcornSSP (~> 2.11.1)
-  - BuzzAdBenefitSDK (6.7.7)
-  - BuzzAvatyeAdCash (6.7.7):
+  - BuzzAdBenefitSDK (6.7.9)
+  - BuzzAvatyeAdCash (6.7.9):
     - AvatyeAdCash (~> 3.4.2)
-    - BuzzAdBenefitSDK (= 6.7.7)
-  - BuzzvilSDK (6.7.7):
-    - BuzzAdBenefitSDK (= 6.7.7)
-    - BuzzvilSDK/Default (= 6.7.7)
-  - BuzzvilSDK/Default (6.7.7):
-    - BuzzAdBenefitSDK (= 6.7.7)
-    - BuzzAvatyeAdCash (= 6.7.7)
+    - BuzzAdBenefitSDK (= 6.7.9)
+  - BuzzvilSDK (6.7.9):
+    - BuzzAdBenefitSDK (= 6.7.9)
+    - BuzzvilSDK/Default (= 6.7.9)
+  - BuzzvilSDK/Default (6.7.9):
+    - BuzzAdBenefitSDK (= 6.7.9)
+    - BuzzAvatyeAdCash (= 6.7.9)
 
 DEPENDENCIES:
-  - BuzzvilSDK (= 6.7.7)
+  - BuzzvilSDK (= 6.7.9)
 
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
@@ -27,10 +27,10 @@ SPEC REPOS:
 SPEC CHECKSUMS:
   AdPopcornSSP: aca347b5f575b3e7d06b76b18be43251d3f21e30
   AvatyeAdCash: feee179adf2811beb35e0917d8eef6efd59b08a6
-  BuzzAdBenefitSDK: 65e902c157984ceeaea00d7d62f27a117bfa3037
-  BuzzAvatyeAdCash: b593259acd92e7a72786cba0db761d9fa8eadb69
-  BuzzvilSDK: 014220a103c6bc5de0fbe6cd0108c07efccd9849
+  BuzzAdBenefitSDK: f5be5131ad268afba322e45cfc352da5799eb7b6
+  BuzzAvatyeAdCash: 403c4f09516d880f41c8796061353b2401070576
+  BuzzvilSDK: cb470055d73c53ea5f1e9be733c382284f587013
 
-PODFILE CHECKSUM: 6a7194bdb661fb4a00a6e9e09933e655d72f21ef
+PODFILE CHECKSUM: 9bd562c9cf49eaa4bc7d86247910454cf751ed44
 
 COCOAPODS: 1.16.2

--- a/buzzvil-sdk-v6-ios/buzzvil-sdk-ios-swift/FlexAd/FlexAdViewController.swift
+++ b/buzzvil-sdk-v6-ios/buzzvil-sdk-ios-swift/FlexAd/FlexAdViewController.swift
@@ -1,6 +1,7 @@
 import UIKit
 import BuzzvilSDK
 
+/// FlexAd를 스크롤 피드 최상단에 배치해, 스크롤 인/아웃에 따른 뷰어빌리티 동작을 확인하는 예시 화면.
 class FlexAdViewController: UIViewController {
 
     private let buzzFlex = BuzzFlex(unitId: "YOUR_FLEX_AD_UNIT_ID")
@@ -11,42 +12,166 @@ class FlexAdViewController: UIViewController {
         return view
     }()
 
+    private let scrollView = UIScrollView()
+
+    private let contentStackView: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .vertical
+        stack.spacing = 16
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        return stack
+    }()
+
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .systemBackground
         navigationItem.title = "FlexAd"
 
         setupLayout()
+        setupSampleContent()
         loadAd()
     }
 
     private func setupLayout() {
-        view.addSubview(flexAdView)
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(scrollView)
+        scrollView.addSubview(contentStackView)
+
         NSLayoutConstraint.activate([
-            flexAdView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 16),
-            flexAdView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            flexAdView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+
+            contentStackView.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor, constant: 16),
+            contentStackView.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor),
+            contentStackView.trailingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.trailingAnchor),
+            contentStackView.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor, constant: -24),
+            // 세로 스크롤만 되도록 stackView 너비를 scrollView 프레임 너비에 고정.
+            contentStackView.widthAnchor.constraint(equalTo: scrollView.frameLayoutGuide.widthAnchor),
         ])
+    }
+
+    private func setupSampleContent() {
+        contentStackView.addArrangedSubview(flexAdView)
+        contentStackView.addArrangedSubview(makeSampleNotice())
+        for (index, item) in Self.sampleFeed.enumerated() {
+            let tint = Self.thumbnailTints[index % Self.thumbnailTints.count]
+            contentStackView.addArrangedSubview(makeSampleCard(item, tint: tint))
+        }
     }
 
     private func loadAd() {
         buzzFlex.delegate = self
         buzzFlex.load()
     }
+
+    // MARK: - 예시용 샘플 콘텐츠
+
+    private struct SampleItem {
+        let title: String
+        let body: String
+        let symbol: String
+    }
+
+    private static let thumbnailTints: [UIColor] = [
+        .systemBlue, .systemGreen, .systemOrange, .systemPurple, .systemPink, .systemTeal,
+    ]
+
+    private static let sampleFeed: [SampleItem] = [
+        SampleItem(title: "샘플 콘텐츠 · 오늘의 주요 소식", body: "스크롤 확인용 예시 콘텐츠입니다.", symbol: "doc.text"),
+        SampleItem(title: "샘플 콘텐츠 · 이번 주 인기 글", body: "실제 서비스 데이터가 아닌 자리표시자입니다.", symbol: "flame"),
+        SampleItem(title: "샘플 콘텐츠 · 라이프스타일 팁", body: "레이아웃 미리보기를 위한 목업 텍스트입니다.", symbol: "sparkles"),
+        SampleItem(title: "샘플 콘텐츠 · 테크 브리핑", body: "예시용으로 채워 넣은 내용입니다.", symbol: "desktopcomputer"),
+        SampleItem(title: "샘플 콘텐츠 · 건강 상식", body: "스크롤 공간 확보를 위한 샘플입니다.", symbol: "heart"),
+        SampleItem(title: "샘플 콘텐츠 · 여행 가이드", body: "실제 콘텐츠가 아닌 예시 텍스트입니다.", symbol: "airplane"),
+        SampleItem(title: "샘플 콘텐츠 · 오늘의 맛집", body: "자리표시자 예시 콘텐츠입니다.", symbol: "cart"),
+        SampleItem(title: "샘플 콘텐츠 · 경제 브리핑", body: "미리보기용 목업 문구입니다.", symbol: "chart.bar"),
+        SampleItem(title: "샘플 콘텐츠 · 문화·이벤트", body: "실제 서비스 데이터가 아닙니다.", symbol: "music.note"),
+        SampleItem(title: "샘플 콘텐츠 · 스포츠 하이라이트", body: "스크롤 확인용 예시 콘텐츠입니다.", symbol: "flag"),
+        SampleItem(title: "샘플 콘텐츠 · 날씨 브리핑", body: "레이아웃 예시를 위한 자리표시자입니다.", symbol: "cloud.sun"),
+        SampleItem(title: "샘플 콘텐츠 · 추천 읽을거리", body: "예시용으로 채워 넣은 목업 텍스트입니다.", symbol: "book"),
+    ]
+
+    private func makeSampleNotice() -> UIView {
+        let label = UILabel()
+        label.text = "· 아래는 스크롤 예시용 샘플 콘텐츠입니다. ·"
+        label.font = .systemFont(ofSize: 12)
+        label.textColor = .tertiaryLabel
+        label.textAlignment = .center
+        label.numberOfLines = 0
+        return label
+    }
+
+    private func makeSampleCard(_ item: SampleItem, tint: UIColor) -> UIView {
+        let container = UIView()
+
+        let thumbnail = UIView()
+        thumbnail.backgroundColor = tint.withAlphaComponent(0.15)
+        thumbnail.layer.cornerRadius = 8
+        thumbnail.translatesAutoresizingMaskIntoConstraints = false
+
+        let thumbnailIcon = UIImageView(image: UIImage(systemName: item.symbol) ?? UIImage(systemName: "photo"))
+        thumbnailIcon.tintColor = tint
+        thumbnailIcon.contentMode = .scaleAspectFit
+        thumbnailIcon.translatesAutoresizingMaskIntoConstraints = false
+        thumbnail.addSubview(thumbnailIcon)
+
+        let titleLabel = UILabel()
+        titleLabel.text = item.title
+        titleLabel.font = .systemFont(ofSize: 15, weight: .semibold)
+        titleLabel.numberOfLines = 2
+
+        let bodyLabel = UILabel()
+        bodyLabel.text = item.body
+        bodyLabel.font = .systemFont(ofSize: 13)
+        bodyLabel.textColor = .secondaryLabel
+        bodyLabel.numberOfLines = 2
+
+        let tagLabel = UILabel()
+        tagLabel.text = "예시"
+        tagLabel.font = .systemFont(ofSize: 10, weight: .semibold)
+        tagLabel.textColor = .tertiaryLabel
+
+        let textStack = UIStackView(arrangedSubviews: [titleLabel, bodyLabel, tagLabel])
+        textStack.axis = .vertical
+        textStack.spacing = 4
+        textStack.translatesAutoresizingMaskIntoConstraints = false
+
+        container.addSubview(thumbnail)
+        container.addSubview(textStack)
+
+        NSLayoutConstraint.activate([
+            thumbnail.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 16),
+            thumbnail.topAnchor.constraint(equalTo: container.topAnchor),
+            thumbnail.widthAnchor.constraint(equalToConstant: 72),
+            thumbnail.heightAnchor.constraint(equalToConstant: 72),
+            thumbnail.bottomAnchor.constraint(lessThanOrEqualTo: container.bottomAnchor),
+
+            thumbnailIcon.centerXAnchor.constraint(equalTo: thumbnail.centerXAnchor),
+            thumbnailIcon.centerYAnchor.constraint(equalTo: thumbnail.centerYAnchor),
+            thumbnailIcon.widthAnchor.constraint(equalToConstant: 30),
+            thumbnailIcon.heightAnchor.constraint(equalToConstant: 30),
+
+            textStack.leadingAnchor.constraint(equalTo: thumbnail.trailingAnchor, constant: 12),
+            textStack.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -16),
+            textStack.topAnchor.constraint(equalTo: container.topAnchor, constant: 2),
+            textStack.bottomAnchor.constraint(lessThanOrEqualTo: container.bottomAnchor, constant: -2),
+
+            container.heightAnchor.constraint(greaterThanOrEqualToConstant: 80),
+        ])
+        return container
+    }
 }
 
 extension FlexAdViewController: BuzzFlexDelegate {
     func buzzFlexOnSuccess() {
-        // 광고 로드 성공 시 호출됩니다.
-        // BuzzFlexAdView에 광고를 표시합니다.
         flexAdView.bind(buzzFlex)
     }
 
     func buzzFlexOnFailure(_ error: Error) {
-        // 광고 로드 실패 시 호출됩니다.
     }
 
     func buzzFlexOnClicked() {
-        // 광고 클릭 시 호출됩니다.
     }
 }


### PR DESCRIPTION
샘플앱 Buzzvil SDK 버전 업데이트 및 FlexAd 뷰어빌리티 예제 화면 추가

- iOS: BuzzvilSDK 6.7.7 → 6.7.9
- Android: buzzvil-bom 6.7.9 → 6.7.10
- FlexAd를 스크롤 피드 최상단에 배치해 뷰어빌리티 동작(VAST 영상 재생/정지)을 확인할 수 있는 예제 화면 추가
