### PR TITLE
FlexAd Mid 예시 화면 추가 (Android/iOS)

### DIFF
--- a/buzzvil-sdk-v6-android/app/src/main/AndroidManifest.xml
+++ b/buzzvil-sdk-v6-android/app/src/main/AndroidManifest.xml
@@ -43,6 +43,9 @@
         <activity
             android:name=".flexad.YourFlexAdActivity"
             android:exported="false" />
+        <activity
+            android:name=".flexad.YourFlexAdMidActivity"
+            android:exported="false" />
 
         <service
             android:name=".pop.YourBuzzPopControlService"

--- a/buzzvil-sdk-v6-android/app/src/main/java/com/buzzvil/sample/buzzvil_sdk_v6_sample/MainActivity.kt
+++ b/buzzvil-sdk-v6-android/app/src/main/java/com/buzzvil/sample/buzzvil_sdk_v6_sample/MainActivity.kt
@@ -15,6 +15,7 @@ import com.buzzvil.buzzbenefit.pop.BuzzPopActivateListener
 import com.buzzvil.sample.buzzvil_sdk_v6_sample.Constant.YOUR_USER_ID
 import com.buzzvil.sample.buzzvil_sdk_v6_sample.banner.YourBannerActivity
 import com.buzzvil.sample.buzzvil_sdk_v6_sample.flexad.YourFlexAdActivity
+import com.buzzvil.sample.buzzvil_sdk_v6_sample.flexad.YourFlexAdMidActivity
 import com.buzzvil.sample.buzzvil_sdk_v6_sample.buzzbenefithub.YourBenefitHubActivity
 import com.buzzvil.sample.buzzvil_sdk_v6_sample.buzzentrypoint.BuzzEntryPointActivity
 import com.buzzvil.sample.buzzvil_sdk_v6_sample.buzznative.YourNativeCarouselActivity
@@ -218,6 +219,11 @@ class MainActivity : AppCompatActivity() {
         // FlexAd
         binding.flexAdButton.setOnClickListener {
             navigateActivity(YourFlexAdActivity::class.java)
+        }
+
+        // FlexAd (Mid)
+        binding.flexAdMidButton.setOnClickListener {
+            navigateActivity(YourFlexAdMidActivity::class.java)
         }
 
 

--- a/buzzvil-sdk-v6-android/app/src/main/java/com/buzzvil/sample/buzzvil_sdk_v6_sample/flexad/YourFlexAdMidActivity.kt
+++ b/buzzvil-sdk-v6-android/app/src/main/java/com/buzzvil/sample/buzzvil_sdk_v6_sample/flexad/YourFlexAdMidActivity.kt
@@ -1,0 +1,161 @@
+package com.buzzvil.sample.buzzvil_sdk_v6_sample.flexad
+
+import android.graphics.Color
+import android.graphics.Typeface
+import android.graphics.drawable.GradientDrawable
+import android.os.Bundle
+import android.util.TypedValue
+import android.view.Gravity
+import android.view.View
+import android.widget.ImageView
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.graphics.ColorUtils
+import com.buzzvil.buzzbenefit.BuzzAdError
+import com.buzzvil.buzzbenefit.flexad.BuzzFlex
+import com.buzzvil.buzzbenefit.flexad.BuzzFlexAdView
+import com.buzzvil.sample.buzzvil_sdk_v6_sample.Constant
+import com.buzzvil.sample.buzzvil_sdk_v6_sample.R
+import com.buzzvil.sample.buzzvil_sdk_v6_sample.databinding.ActivityYourFlexAdMidBinding
+
+/**
+ * FlexAd를 스크롤 피드 중간에 배치해, 위/아래 콘텐츠 사이에서의 뷰어빌리티 동작을 확인하는 예시 화면.
+ */
+class YourFlexAdMidActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityYourFlexAdMidBinding
+    private lateinit var buzzFlex: BuzzFlex
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        title = "FlexAd (Mid)"
+        binding = ActivityYourFlexAdMidBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        val buzzFlexAdView = BuzzFlexAdView(this)
+
+        setupSampleContent(buzzFlexAdView)
+
+        buzzFlex = BuzzFlex(Constant.YOUR_FLEX_AD_ID)
+        buzzFlex.setListener(object : BuzzFlex.Listener {
+            override fun onSuccess() {
+                buzzFlexAdView.bind(buzzFlex)
+            }
+
+            override fun onFailure(adError: BuzzAdError) {}
+
+            override fun onClicked() {}
+        })
+        buzzFlex.load()
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        buzzFlex.dispose()
+    }
+
+    // MARK: - 예시용 샘플 콘텐츠
+
+    private data class SampleItem(val title: String, val body: String)
+
+    private fun setupSampleContent(buzzFlexAdView: BuzzFlexAdView) {
+        // 위쪽 리스트
+        sampleFeed.forEachIndexed { index, item ->
+            binding.contentContainer.addView(makeSampleCard(item, thumbnailTints[index % thumbnailTints.size]))
+        }
+        // 가운데 FlexAd
+        binding.contentContainer.addView(buzzFlexAdView, LinearLayout.LayoutParams(
+            LinearLayout.LayoutParams.MATCH_PARENT,
+            LinearLayout.LayoutParams.WRAP_CONTENT,
+        ).apply { setMargins(dp(16), dp(8), dp(16), dp(8)) })
+        // 아래쪽 리스트
+        sampleFeed.forEachIndexed { index, item ->
+            binding.contentContainer.addView(makeSampleCard(item, thumbnailTints[index % thumbnailTints.size]))
+        }
+    }
+
+    private fun makeSampleCard(item: SampleItem, tint: Int): View {
+        val row = LinearLayout(this).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.CENTER_VERTICAL
+            layoutParams = LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT,
+                LinearLayout.LayoutParams.WRAP_CONTENT,
+            ).apply { setMargins(dp(16), dp(8), dp(16), dp(8)) }
+        }
+
+        val thumbnail = ImageView(this).apply {
+            setImageResource(R.drawable.ic_sample_image)
+            setColorFilter(tint)
+            scaleType = ImageView.ScaleType.CENTER_INSIDE
+            setPadding(dp(20), dp(20), dp(20), dp(20))
+            background = GradientDrawable().apply {
+                cornerRadius = dp(8).toFloat()
+                setColor(ColorUtils.setAlphaComponent(tint, 38))
+            }
+            layoutParams = LinearLayout.LayoutParams(dp(72), dp(72))
+        }
+        row.addView(thumbnail)
+
+        val textColumn = LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            layoutParams = LinearLayout.LayoutParams(
+                0,
+                LinearLayout.LayoutParams.WRAP_CONTENT,
+                1f,
+            ).apply { marginStart = dp(12) }
+        }
+        textColumn.addView(TextView(this).apply {
+            text = item.title
+            setTextColor(Color.parseColor("#1C1C1E"))
+            textSize = 15f
+            setTypeface(typeface, Typeface.BOLD)
+            maxLines = 2
+        })
+        textColumn.addView(TextView(this).apply {
+            text = item.body
+            setTextColor(Color.parseColor("#6E6E73"))
+            textSize = 13f
+            maxLines = 2
+        })
+        textColumn.addView(TextView(this).apply {
+            text = "예시"
+            setTextColor(Color.parseColor("#AEAEB2"))
+            textSize = 10f
+            setTypeface(typeface, Typeface.BOLD)
+        })
+        row.addView(textColumn)
+
+        return row
+    }
+
+    private fun dp(value: Int): Int =
+        TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, value.toFloat(), resources.displayMetrics).toInt()
+
+    private companion object {
+        val thumbnailTints = intArrayOf(
+            Color.parseColor("#007AFF"),
+            Color.parseColor("#34C759"),
+            Color.parseColor("#FF9500"),
+            Color.parseColor("#AF52DE"),
+            Color.parseColor("#FF2D55"),
+            Color.parseColor("#30B0C7"),
+        )
+
+        val sampleFeed = listOf(
+            SampleItem("샘플 콘텐츠 · 오늘의 주요 소식", "스크롤 확인용 예시 콘텐츠입니다."),
+            SampleItem("샘플 콘텐츠 · 이번 주 인기 글", "실제 서비스 데이터가 아닌 자리표시자입니다."),
+            SampleItem("샘플 콘텐츠 · 라이프스타일 팁", "레이아웃 미리보기를 위한 목업 텍스트입니다."),
+            SampleItem("샘플 콘텐츠 · 테크 브리핑", "예시용으로 채워 넣은 내용입니다."),
+            SampleItem("샘플 콘텐츠 · 건강 상식", "스크롤 공간 확보를 위한 샘플입니다."),
+            SampleItem("샘플 콘텐츠 · 여행 가이드", "실제 콘텐츠가 아닌 예시 텍스트입니다."),
+            SampleItem("샘플 콘텐츠 · 오늘의 맛집", "자리표시자 예시 콘텐츠입니다."),
+            SampleItem("샘플 콘텐츠 · 경제 브리핑", "미리보기용 목업 문구입니다."),
+            SampleItem("샘플 콘텐츠 · 문화·이벤트", "실제 서비스 데이터가 아닙니다."),
+            SampleItem("샘플 콘텐츠 · 스포츠 하이라이트", "스크롤 확인용 예시 콘텐츠입니다."),
+            SampleItem("샘플 콘텐츠 · 날씨 브리핑", "레이아웃 예시를 위한 자리표시자입니다."),
+            SampleItem("샘플 콘텐츠 · 추천 읽을거리", "예시용으로 채워 넣은 목업 텍스트입니다."),
+        )
+    }
+}

--- a/buzzvil-sdk-v6-android/app/src/main/res/layout/activity_main.xml
+++ b/buzzvil-sdk-v6-android/app/src/main/res/layout/activity_main.xml
@@ -241,6 +241,13 @@
                 android:layout_marginHorizontal="16dp"
                 android:text="FlexAd" />
 
+            <Button
+                android:id="@+id/flexAdMidButton"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="16dp"
+                android:text="FlexAd (Mid)" />
+
         </LinearLayout>
     </ScrollView>
 </FrameLayout>

--- a/buzzvil-sdk-v6-android/app/src/main/res/layout/activity_your_flex_ad_mid.xml
+++ b/buzzvil-sdk-v6-android/app/src/main/res/layout/activity_your_flex_ad_mid.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:id="@+id/contentContainer"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingTop="16dp"
+        android:paddingBottom="16dp" />
+</ScrollView>

--- a/buzzvil-sdk-v6-ios/buzzvil-sdk-ios-swift/FlexAd/FlexAdMidViewController.swift
+++ b/buzzvil-sdk-v6-ios/buzzvil-sdk-ios-swift/FlexAd/FlexAdMidViewController.swift
@@ -1,0 +1,173 @@
+import UIKit
+import BuzzvilSDK
+
+/// FlexAd를 스크롤 피드 중간에 배치해, 위/아래 콘텐츠 사이에서의 뷰어빌리티 동작을 확인하는 예시 화면.
+class FlexAdMidViewController: UIViewController {
+
+    private let buzzFlex = BuzzFlex(unitId: "YOUR_FLEX_AD_UNIT_ID")
+
+    private lazy var flexAdView: BuzzFlexAdView = {
+        let view = BuzzFlexAdView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private let scrollView = UIScrollView()
+
+    private let contentStackView: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .vertical
+        stack.spacing = 16
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        return stack
+    }()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .systemBackground
+        navigationItem.title = "FlexAd (Mid)"
+
+        setupLayout()
+        setupSampleContent()
+        loadAd()
+    }
+
+    private func setupLayout() {
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(scrollView)
+        scrollView.addSubview(contentStackView)
+
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+
+            contentStackView.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor, constant: 16),
+            contentStackView.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor),
+            contentStackView.trailingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.trailingAnchor),
+            contentStackView.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor, constant: -24),
+            // 세로 스크롤만 되도록 stackView 너비를 scrollView 프레임 너비에 고정.
+            contentStackView.widthAnchor.constraint(equalTo: scrollView.frameLayoutGuide.widthAnchor),
+        ])
+    }
+
+    private func setupSampleContent() {
+        // 위쪽 리스트
+        for (index, item) in Self.sampleFeed.enumerated() {
+            let tint = Self.thumbnailTints[index % Self.thumbnailTints.count]
+            contentStackView.addArrangedSubview(makeSampleCard(item, tint: tint))
+        }
+        // 가운데 FlexAd
+        contentStackView.addArrangedSubview(flexAdView)
+        // 아래쪽 리스트
+        for (index, item) in Self.sampleFeed.enumerated() {
+            let tint = Self.thumbnailTints[index % Self.thumbnailTints.count]
+            contentStackView.addArrangedSubview(makeSampleCard(item, tint: tint))
+        }
+    }
+
+    private func loadAd() {
+        buzzFlex.delegate = self
+        buzzFlex.load()
+    }
+
+    // MARK: - 예시용 샘플 콘텐츠
+
+    private struct SampleItem {
+        let title: String
+        let body: String
+        let symbol: String
+    }
+
+    private static let thumbnailTints: [UIColor] = [
+        .systemBlue, .systemGreen, .systemOrange, .systemPurple, .systemPink, .systemTeal,
+    ]
+
+    private static let sampleFeed: [SampleItem] = [
+        SampleItem(title: "샘플 콘텐츠 · 오늘의 주요 소식", body: "스크롤 확인용 예시 콘텐츠입니다.", symbol: "doc.text"),
+        SampleItem(title: "샘플 콘텐츠 · 이번 주 인기 글", body: "실제 서비스 데이터가 아닌 자리표시자입니다.", symbol: "flame"),
+        SampleItem(title: "샘플 콘텐츠 · 라이프스타일 팁", body: "레이아웃 미리보기를 위한 목업 텍스트입니다.", symbol: "sparkles"),
+        SampleItem(title: "샘플 콘텐츠 · 테크 브리핑", body: "예시용으로 채워 넣은 내용입니다.", symbol: "desktopcomputer"),
+        SampleItem(title: "샘플 콘텐츠 · 건강 상식", body: "스크롤 공간 확보를 위한 샘플입니다.", symbol: "heart"),
+        SampleItem(title: "샘플 콘텐츠 · 여행 가이드", body: "실제 콘텐츠가 아닌 예시 텍스트입니다.", symbol: "airplane"),
+        SampleItem(title: "샘플 콘텐츠 · 오늘의 맛집", body: "자리표시자 예시 콘텐츠입니다.", symbol: "cart"),
+        SampleItem(title: "샘플 콘텐츠 · 경제 브리핑", body: "미리보기용 목업 문구입니다.", symbol: "chart.bar"),
+        SampleItem(title: "샘플 콘텐츠 · 문화·이벤트", body: "실제 서비스 데이터가 아닙니다.", symbol: "music.note"),
+        SampleItem(title: "샘플 콘텐츠 · 스포츠 하이라이트", body: "스크롤 확인용 예시 콘텐츠입니다.", symbol: "flag"),
+        SampleItem(title: "샘플 콘텐츠 · 날씨 브리핑", body: "레이아웃 예시를 위한 자리표시자입니다.", symbol: "cloud.sun"),
+        SampleItem(title: "샘플 콘텐츠 · 추천 읽을거리", body: "예시용으로 채워 넣은 목업 텍스트입니다.", symbol: "book"),
+    ]
+
+    private func makeSampleCard(_ item: SampleItem, tint: UIColor) -> UIView {
+        let container = UIView()
+
+        let thumbnail = UIView()
+        thumbnail.backgroundColor = tint.withAlphaComponent(0.15)
+        thumbnail.layer.cornerRadius = 8
+        thumbnail.translatesAutoresizingMaskIntoConstraints = false
+
+        let thumbnailIcon = UIImageView(image: UIImage(systemName: item.symbol) ?? UIImage(systemName: "photo"))
+        thumbnailIcon.tintColor = tint
+        thumbnailIcon.contentMode = .scaleAspectFit
+        thumbnailIcon.translatesAutoresizingMaskIntoConstraints = false
+        thumbnail.addSubview(thumbnailIcon)
+
+        let titleLabel = UILabel()
+        titleLabel.text = item.title
+        titleLabel.font = .systemFont(ofSize: 15, weight: .semibold)
+        titleLabel.numberOfLines = 2
+
+        let bodyLabel = UILabel()
+        bodyLabel.text = item.body
+        bodyLabel.font = .systemFont(ofSize: 13)
+        bodyLabel.textColor = .secondaryLabel
+        bodyLabel.numberOfLines = 2
+
+        let tagLabel = UILabel()
+        tagLabel.text = "예시"
+        tagLabel.font = .systemFont(ofSize: 10, weight: .semibold)
+        tagLabel.textColor = .tertiaryLabel
+
+        let textStack = UIStackView(arrangedSubviews: [titleLabel, bodyLabel, tagLabel])
+        textStack.axis = .vertical
+        textStack.spacing = 4
+        textStack.translatesAutoresizingMaskIntoConstraints = false
+
+        container.addSubview(thumbnail)
+        container.addSubview(textStack)
+
+        NSLayoutConstraint.activate([
+            thumbnail.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 16),
+            thumbnail.topAnchor.constraint(equalTo: container.topAnchor),
+            thumbnail.widthAnchor.constraint(equalToConstant: 72),
+            thumbnail.heightAnchor.constraint(equalToConstant: 72),
+            thumbnail.bottomAnchor.constraint(lessThanOrEqualTo: container.bottomAnchor),
+
+            thumbnailIcon.centerXAnchor.constraint(equalTo: thumbnail.centerXAnchor),
+            thumbnailIcon.centerYAnchor.constraint(equalTo: thumbnail.centerYAnchor),
+            thumbnailIcon.widthAnchor.constraint(equalToConstant: 30),
+            thumbnailIcon.heightAnchor.constraint(equalToConstant: 30),
+
+            textStack.leadingAnchor.constraint(equalTo: thumbnail.trailingAnchor, constant: 12),
+            textStack.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -16),
+            textStack.topAnchor.constraint(equalTo: container.topAnchor, constant: 2),
+            textStack.bottomAnchor.constraint(lessThanOrEqualTo: container.bottomAnchor, constant: -2),
+
+            container.heightAnchor.constraint(greaterThanOrEqualToConstant: 80),
+        ])
+        return container
+    }
+}
+
+extension FlexAdMidViewController: BuzzFlexDelegate {
+    func buzzFlexOnSuccess() {
+        flexAdView.bind(buzzFlex)
+    }
+
+    func buzzFlexOnFailure(_ error: Error) {
+    }
+
+    func buzzFlexOnClicked() {
+    }
+}

--- a/buzzvil-sdk-v6-ios/buzzvil-sdk-ios-swift/ViewController.swift
+++ b/buzzvil-sdk-v6-ios/buzzvil-sdk-ios-swift/ViewController.swift
@@ -72,6 +72,13 @@ class ViewController: UIViewController {
     button.addTarget(self, action: #selector(pushFlexAdViewController), for: .touchUpInside)
     return button
   }()
+
+  private lazy var flexAdMidButton: UIButton = {
+    let button = UIButton(frame: .zero)
+    button.setTitle("FlexAd (Mid)", for: .normal)
+    button.addTarget(self, action: #selector(pushFlexAdMidViewController), for: .touchUpInside)
+    return button
+  }()
   
   private lazy var inquiryButton: UIButton = {
     let button = UIButton(frame: .zero)
@@ -125,6 +132,7 @@ class ViewController: UIViewController {
     rootStackView.addArrangedSubview(bannerButton)
     rootStackView.addArrangedSubview(entryPointButton)
     rootStackView.addArrangedSubview(flexAdButton)
+    rootStackView.addArrangedSubview(flexAdMidButton)
     rootStackView.addArrangedSubview(inquiryButton)
     rootStackView.addArrangedSubview(privacyConsentStatusLabel)
     rootStackView.addArrangedSubview(loadPrivacyConsentStatusButton)
@@ -142,6 +150,7 @@ class ViewController: UIViewController {
       bannerButton,
       entryPointButton,
       flexAdButton,
+      flexAdMidButton,
       inquiryButton,
       loadPrivacyConsentStatusButton,
       grantPrivacyConsentButton,
@@ -216,6 +225,11 @@ class ViewController: UIViewController {
   @objc private func pushFlexAdViewController() {
     let flexAdViewController = FlexAdViewController()
     navigationController?.pushViewController(flexAdViewController, animated: true)
+  }
+
+  @objc private func pushFlexAdMidViewController() {
+    let flexAdMidViewController = FlexAdMidViewController()
+    navigationController?.pushViewController(flexAdMidViewController, animated: true)
   }
   
   @objc private func showInquiry() {

--- a/buzzvil-sdk-v6-ios/buzzvil-sdk-ios-v6.xcodeproj/project.pbxproj
+++ b/buzzvil-sdk-v6-ios/buzzvil-sdk-ios-v6.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		008FB3752D8909F400DA135E /* BenefitHubContainerViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 008FB3642D8909F400DA135E /* BenefitHubContainerViewController.m */; };
 		008FB3762D8909F400DA135E /* UIButton+Custom.m in Sources */ = {isa = PBXBuildFile; fileRef = 008FB3402D8909F400DA135E /* UIButton+Custom.m */; };
 		45B7DF90249E277C9C58C0A3 /* FlexAdViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6D40A31A9D7AC52F9DFEE9 /* FlexAdViewController.swift */; };
+		45B7DF90249E277C9C58C0B0 /* FlexAdMidViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6D40A31A9D7AC52F9DFEF0 /* FlexAdMidViewController.swift */; };
 		6520320D2E20F92500B1B227 /* EntryPointViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 6520320C2E20F92500B1B227 /* EntryPointViewController.m */; };
 		652032102E20FD7500B1B227 /* EntryPointView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6520320F2E20FD7500B1B227 /* EntryPointView.swift */; };
 		654651552DAE406700684E6F /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 654651522DAE406700684E6F /* ContentView.swift */; };
@@ -124,6 +125,7 @@
 		65BB66F62DB22B3D000D1381 /* BannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerView.swift; sourceTree = "<group>"; };
 		65BB66F92DB22FD5000D1381 /* PrivacyConsentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyConsentView.swift; sourceTree = "<group>"; };
 		8A6D40A31A9D7AC52F9DFEE9 /* FlexAdViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FlexAdViewController.swift; sourceTree = "<group>"; };
+		8A6D40A31A9D7AC52F9DFEF0 /* FlexAdMidViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FlexAdMidViewController.swift; sourceTree = "<group>"; };
 		9DF2B4AF44BEA0294F33A1FA /* Pods_buzzvil_sdk_ios_objc.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_buzzvil_sdk_ios_objc.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A6C9481B4C732CB7679FBAD3 /* Pods-buzzvil-sdk-ios-v6.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-buzzvil-sdk-ios-v6.debug.xcconfig"; path = "Target Support Files/Pods-buzzvil-sdk-ios-v6/Pods-buzzvil-sdk-ios-v6.debug.xcconfig"; sourceTree = "<group>"; };
 		C0CD1C640147ADD6CAF2754C /* Pods_buzzvil_sdk_ios_swift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_buzzvil_sdk_ios_swift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -436,6 +438,7 @@
 			isa = PBXGroup;
 			children = (
 				8A6D40A31A9D7AC52F9DFEE9 /* FlexAdViewController.swift */,
+				8A6D40A31A9D7AC52F9DFEF0 /* FlexAdMidViewController.swift */,
 			);
 			name = FlexAd;
 			path = FlexAd;
@@ -802,6 +805,7 @@
 				0041F5302D87EE7C00B901E2 /* BenefitHubContainerViewController.swift in Sources */,
 				0041F5312D87EE7C00B901E2 /* CarouselViewController.swift in Sources */,
 				45B7DF90249E277C9C58C0A3 /* FlexAdViewController.swift in Sources */,
+				45B7DF90249E277C9C58C0B0 /* FlexAdMidViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
## 개요

FlexAd를 스크롤 피드 **중간**에 배치한 예시 화면을 Android/iOS 양쪽 샘플 앱에 추가합니다. 기존 `FlexAd`(최상단 배치)에 이어, 위/아래 콘텐츠 사이에서의 뷰어빌리티 동작을 확인할 수 있습니다.

레이아웃 구조: `샘플 리스트 → FlexAdView → 샘플 리스트`

## 변경 사항

### Android
- `YourFlexAdMidActivity.kt` + `activity_your_flex_ad_mid.xml` 신규 추가
- `AndroidManifest.xml`에 액티비티 등록
- 메인 화면에 `FlexAd (Mid)` 진입 버튼 연결

### iOS
- `FlexAdMidViewController.swift` 신규 추가
- `project.pbxproj`에 소스 파일 등록
- `ViewController`에 `FlexAd (Mid)` 진입 버튼 연결

## 검증
- Android: `compileDebugKotlin` 통과
- iOS: 시뮬레이터 빌드(`BUILD SUCCEEDED`) 통과